### PR TITLE
Use full filenames for DOSBox image mounting

### DIFF
--- a/src/funciones.cpp
+++ b/src/funciones.cpp
@@ -2483,7 +2483,7 @@ QStringList Funciones::creaConfigMontajes(QTreeWidget *twDbxMount, stConfigDOSBo
 					lista_multiple_iso.clear();
 					const int lmiso_Size = lista_isos.size();
 					for (int i = 0; i < lmiso_Size; ++i)
-						lista_multiple_iso << "\""+ getShortPathName( getDirRelative(lista_isos.at(i), "DosGames") ) +"\"";
+						lista_multiple_iso << "\""+ getDirRelative(lista_isos.at(i), "DosGames") +"\"";
 					mount_drive.clear();
 					mount_drive = lista_multiple_iso.join(" ");
 				}
@@ -2519,7 +2519,7 @@ QStringList Funciones::creaConfigMontajes(QTreeWidget *twDbxMount, stConfigDOSBo
 				const int lmisoSize = lista_isos.size();
 				for (int i = 0; i < lmisoSize; ++i)
 				{
-					lista_multiple_iso << "\""+ getShortPathName( getDirRelative(lista_isos.at(i), "DosGames") ) +"\"";
+					lista_multiple_iso << "\""+ getDirRelative(lista_isos.at(i), "DosGames") +"\"";
 				}
 				mount_drive.clear();
 				mount_drive = lista_multiple_iso.join(" ");


### PR DESCRIPTION
I'm not sure why the function call to getShortPathName was added, but currently mounting "Multiple ISO images" and "Bootable image" doesn't work on Linux (and I'd assume also on Windows machines where 8.3 support is disabled in the file system). DOSBox's imgmount requires the full path as seen by the host OS, so the conversion to DOS 8.3 syntax is probably incorrect here (but will probably work on a default Windows system nevertheless due to the OS's built in support of 8.3 file syntax).