### PR TITLE
Elimina referencia a psx-1.png que fue borrada en el commit 31f630e.

### DIFF
--- a/res/gr-lida.qrc
+++ b/res/gr-lida.qrc
@@ -445,7 +445,6 @@
         <file>img16/pdf.png</file>
         <file>img16/pictureflow.png</file>
         <file>img16/psx.png</file>
-        <file>img16/psx-1.png</file>
         <file>img16/qt.png</file>
         <file>img16/rotar.png</file>
         <file>img16/ruleta.png</file>


### PR DESCRIPTION
La compilación falla sin este cambio porque no encuentra la imagen.