### PR TITLE
Update / fix English translation

### DIFF
--- a/res/idiomas/gr-lida_da_DK.ts
+++ b/res/idiomas/gr-lida_da_DK.ts
@@ -241,188 +241,188 @@
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="978"/>
+        <location filename="../../src/funciones.cpp" line="980"/>
         <source>CarÃ¡tula frontal</source>
         <translation>Front cover</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="979"/>
+        <location filename="../../src/funciones.cpp" line="981"/>
         <source>Detalles del juego</source>
         <translation>Nærmere oplysninger om spillet</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="980"/>
+        <location filename="../../src/funciones.cpp" line="982"/>
         <source>CalificaciÃ³n</source>
         <translation>Karakter</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="981"/>
+        <location filename="../../src/funciones.cpp" line="983"/>
         <source>Otros datos</source>
         <translation>Andre data</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="982"/>
+        <location filename="../../src/funciones.cpp" line="984"/>
         <source>Subido por</source>
         <translation>Overført af</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="983"/>
+        <location filename="../../src/funciones.cpp" line="985"/>
         <source>SubtÃ­tulo</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="984"/>
+        <location filename="../../src/funciones.cpp" line="986"/>
         <source>Publicado por</source>
         <translation>Udgiver af</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="985"/>
+        <location filename="../../src/funciones.cpp" line="987"/>
         <source>Desarrollado por</source>
         <translation>Developer ved</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="986"/>
+        <location filename="../../src/funciones.cpp" line="988"/>
         <source>Publicado</source>
         <translation>Udgiver</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="987"/>
+        <location filename="../../src/funciones.cpp" line="989"/>
         <source>Edad recomendada</source>
         <translation>Anbefalet alder</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="988"/>
+        <location filename="../../src/funciones.cpp" line="990"/>
         <source>Idioma</source>
         <translation>Sprog</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="989"/>
+        <location filename="../../src/funciones.cpp" line="991"/>
         <source>Idioma voces</source>
         <translation>Sprog voices</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="990"/>
+        <location filename="../../src/funciones.cpp" line="992"/>
         <source>Formato</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="991"/>
+        <location filename="../../src/funciones.cpp" line="993"/>
         <source>Genero</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="992"/>
+        <location filename="../../src/funciones.cpp" line="994"/>
         <source>Tema</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="993"/>
+        <location filename="../../src/funciones.cpp" line="995"/>
         <source>Grupo</source>
         <translation>Gruppe</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="994"/>
+        <location filename="../../src/funciones.cpp" line="996"/>
         <source>Perspectiva</source>
         <translation>Perspektiv</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="995"/>
+        <location filename="../../src/funciones.cpp" line="997"/>
         <source>Sistema operativo</source>
         <translation>OS</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="996"/>
+        <location filename="../../src/funciones.cpp" line="998"/>
         <source>Favorito</source>
         <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>Joystick</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>GamePad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="998"/>
+        <location filename="../../src/funciones.cpp" line="1000"/>
         <source>AÃ±adido el</source>
         <translation>Tilføjet</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="999"/>
+        <location filename="../../src/funciones.cpp" line="1001"/>
         <source>GrÃ¡ficos</source>
         <translation>Grafik</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1000"/>
+        <location filename="../../src/funciones.cpp" line="1002"/>
         <source>Sonido</source>
         <translation>Lyd</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1001"/>
+        <location filename="../../src/funciones.cpp" line="1003"/>
         <source>Jugabilidad</source>
         <translation>Spilbarhed</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1002"/>
+        <location filename="../../src/funciones.cpp" line="1004"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1003"/>
+        <location filename="../../src/funciones.cpp" line="1005"/>
         <source>Estado</source>
         <translation>Stat</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1004"/>
+        <location filename="../../src/funciones.cpp" line="1006"/>
         <source>Tipo Emu</source>
         <translation>Emu type</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1005"/>
+        <location filename="../../src/funciones.cpp" line="1007"/>
         <source>DescripciÃ³n</source>
         <translation>Beskrivelse</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1006"/>
+        <location filename="../../src/funciones.cpp" line="1008"/>
         <source>Rating</source>
         <translation>Bedømmelse</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1007"/>
+        <location filename="../../src/funciones.cpp" line="1009"/>
         <source>NÂº discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1011"/>
+        <location filename="../../src/funciones.cpp" line="1013"/>
         <source>TÃ­tulo</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1012"/>
+        <location filename="../../src/funciones.cpp" line="1014"/>
         <source>TÃ­tulo album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1013"/>
+        <location filename="../../src/funciones.cpp" line="1015"/>
         <source>Artista album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1928"/>
+        <location filename="../../src/funciones.cpp" line="1930"/>
         <source>ConfiguraciÃ³n por defecto</source>
         <translation>Standardkonfiguration</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1933"/>
-        <location filename="../../src/funciones.cpp" line="1934"/>
+        <location filename="../../src/funciones.cpp" line="1935"/>
+        <location filename="../../src/funciones.cpp" line="1936"/>
         <source>Importar desde un archivo</source>
         <translation>Import fra fil</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1960"/>
+        <location filename="../../src/funciones.cpp" line="1962"/>
         <source>exterior</source>
         <translation>ekstern</translation>
     </message>
@@ -876,14 +876,14 @@
 <context>
     <name>GrLida</name>
     <message>
-        <location filename="../../src/grlida.cpp" line="1604"/>
+        <location filename="../../src/grlida.cpp" line="1616"/>
         <source>Por ID</source>
         <translation>Af ID</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1985"/>
-        <location filename="../../src/grlida.cpp" line="1607"/>
-        <location filename="../../src/grlida.cpp" line="2035"/>
+        <location filename="../../src/grlida.cpp" line="1619"/>
+        <location filename="../../src/grlida.cpp" line="2047"/>
         <source>Genero</source>
         <translation>Genre</translation>
     </message>
@@ -1408,9 +1408,9 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1470"/>
-        <location filename="../../src/grlida.cpp" line="3835"/>
-        <location filename="../../src/grlida.cpp" line="3836"/>
-        <location filename="../../src/grlida.cpp" line="3837"/>
+        <location filename="../../src/grlida.cpp" line="3857"/>
+        <location filename="../../src/grlida.cpp" line="3858"/>
+        <location filename="../../src/grlida.cpp" line="3859"/>
         <source>PictureFlow como principal</source>
         <translation>PictureFlow indstillet som standard</translation>
     </message>
@@ -1430,7 +1430,7 @@
         <location filename="../../ui/grlida.ui" line="1679"/>
         <location filename="../../ui/grlida.ui" line="1769"/>
         <location filename="../../ui/grlida.ui" line="1772"/>
-        <location filename="../../src/grlida.cpp" line="3303"/>
+        <location filename="../../src/grlida.cpp" line="3325"/>
         <source>Archivos</source>
         <translation>Fil</translation>
     </message>
@@ -1602,7 +1602,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1969"/>
-        <location filename="../../src/grlida.cpp" line="2032"/>
+        <location filename="../../src/grlida.cpp" line="2044"/>
         <source>Icono</source>
         <translation>Ikoner</translation>
     </message>
@@ -1618,35 +1618,35 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2001"/>
-        <location filename="../../src/grlida.cpp" line="1609"/>
-        <location filename="../../src/grlida.cpp" line="2037"/>
+        <location filename="../../src/grlida.cpp" line="1621"/>
+        <location filename="../../src/grlida.cpp" line="2049"/>
         <source>Desarrollador</source>
         <translation>Developer</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2009"/>
-        <location filename="../../src/grlida.cpp" line="1610"/>
-        <location filename="../../src/grlida.cpp" line="2038"/>
+        <location filename="../../src/grlida.cpp" line="1622"/>
+        <location filename="../../src/grlida.cpp" line="2050"/>
         <source>Tema</source>
         <translation>Tema</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2017"/>
-        <location filename="../../src/grlida.cpp" line="2039"/>
+        <location filename="../../src/grlida.cpp" line="2051"/>
         <source>Grupo</source>
         <translation>Gruppe</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2033"/>
-        <location filename="../../src/grlida.cpp" line="1611"/>
-        <location filename="../../src/grlida.cpp" line="2041"/>
+        <location filename="../../src/grlida.cpp" line="1623"/>
+        <location filename="../../src/grlida.cpp" line="2053"/>
         <source>Idioma</source>
         <translation>Sprog</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2049"/>
-        <location filename="../../src/grlida.cpp" line="1612"/>
-        <location filename="../../src/grlida.cpp" line="2043"/>
+        <location filename="../../src/grlida.cpp" line="1624"/>
+        <location filename="../../src/grlida.cpp" line="2055"/>
         <source>Formato</source>
         <translation>Format</translation>
     </message>
@@ -1657,7 +1657,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2073"/>
-        <location filename="../../src/grlida.cpp" line="2046"/>
+        <location filename="../../src/grlida.cpp" line="2058"/>
         <source>Sistema</source>
         <translation>OS</translation>
     </message>
@@ -1683,13 +1683,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2170"/>
-        <location filename="../../src/grlida.cpp" line="2057"/>
+        <location filename="../../src/grlida.cpp" line="2069"/>
         <source>Edad</source>
         <translation>Alder</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2178"/>
-        <location filename="../../src/grlida.cpp" line="2058"/>
+        <location filename="../../src/grlida.cpp" line="2070"/>
         <source>Usuario</source>
         <translation>Brugernavn</translation>
     </message>
@@ -1803,7 +1803,7 @@
         <translation>Har files / dækker</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3295"/>
+        <location filename="../../src/grlida.cpp" line="3317"/>
         <source>Capturas de sonidos</source>
         <translation>Lyd  indfanger</translation>
     </message>
@@ -1860,48 +1860,48 @@
         <translation>&amp;Gendan</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1615"/>
+        <location filename="../../src/grlida.cpp" line="1627"/>
         <source>Sistema OS</source>
         <translation>OS</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2097"/>
-        <location filename="../../src/grlida.cpp" line="1617"/>
-        <location filename="../../src/grlida.cpp" line="2049"/>
+        <location filename="../../src/grlida.cpp" line="1629"/>
+        <location filename="../../src/grlida.cpp" line="2061"/>
         <source>Sonido</source>
         <translation>Lyd</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2105"/>
-        <location filename="../../src/grlida.cpp" line="1618"/>
-        <location filename="../../src/grlida.cpp" line="2050"/>
+        <location filename="../../src/grlida.cpp" line="1630"/>
+        <location filename="../../src/grlida.cpp" line="2062"/>
         <source>Jugabilidad</source>
         <translation>Spilbarhed</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2113"/>
-        <location filename="../../src/grlida.cpp" line="1619"/>
-        <location filename="../../src/grlida.cpp" line="2051"/>
+        <location filename="../../src/grlida.cpp" line="1631"/>
+        <location filename="../../src/grlida.cpp" line="2063"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1620"/>
-        <location filename="../../src/grlida.cpp" line="2295"/>
+        <location filename="../../src/grlida.cpp" line="1632"/>
+        <location filename="../../src/grlida.cpp" line="2307"/>
         <source>Tipo emulador</source>
         <translation>Emulator type</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2151"/>
-        <location filename="../../src/grlida.cpp" line="1621"/>
-        <location filename="../../src/grlida.cpp" line="2055"/>
+        <location filename="../../src/grlida.cpp" line="1633"/>
+        <location filename="../../src/grlida.cpp" line="2067"/>
         <source>Favorito</source>
         <translation>Favorit</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2162"/>
-        <location filename="../../src/grlida.cpp" line="1622"/>
-        <location filename="../../src/grlida.cpp" line="2056"/>
+        <location filename="../../src/grlida.cpp" line="1634"/>
+        <location filename="../../src/grlida.cpp" line="2068"/>
         <source>Rating</source>
         <translation></translation>
     </message>
@@ -1911,12 +1911,12 @@
         <translation>af</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1626"/>
+        <location filename="../../src/grlida.cpp" line="1638"/>
         <source>Ascendente</source>
         <translation>Stigende</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1627"/>
+        <location filename="../../src/grlida.cpp" line="1639"/>
         <source>Descendente</source>
         <translation>Descending</translation>
     </message>
@@ -1926,17 +1926,17 @@
         <translation>Sorter</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2289"/>
+        <location filename="../../src/grlida.cpp" line="2301"/>
         <source>Todos</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2290"/>
+        <location filename="../../src/grlida.cpp" line="2302"/>
         <source>Favoritos</source>
         <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2291"/>
+        <location filename="../../src/grlida.cpp" line="2303"/>
         <source>Originales</source>
         <translation>Original</translation>
     </message>
@@ -1946,31 +1946,31 @@
         <translation>Fejl ved åbning database</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2526"/>
+        <location filename="../../src/grlida.cpp" line="2540"/>
         <source>Datos</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2558"/>
+        <location filename="../../src/grlida.cpp" line="2572"/>
         <source>Otro emulador</source>
         <translation>Andre emulatorer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3807"/>
-        <location filename="../../src/grlida.cpp" line="3808"/>
-        <location filename="../../src/grlida.cpp" line="3809"/>
+        <location filename="../../src/grlida.cpp" line="3829"/>
+        <location filename="../../src/grlida.cpp" line="3830"/>
+        <location filename="../../src/grlida.cpp" line="3831"/>
         <source>Ver lista de juegos</source>
         <translation>Vis liste spil</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3810"/>
+        <location filename="../../src/grlida.cpp" line="3832"/>
         <source>Lista de juegos</source>
         <translation>Spil liste</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3813"/>
-        <location filename="../../src/grlida.cpp" line="3814"/>
-        <location filename="../../src/grlida.cpp" line="3815"/>
+        <location filename="../../src/grlida.cpp" line="3835"/>
+        <location filename="../../src/grlida.cpp" line="3836"/>
+        <location filename="../../src/grlida.cpp" line="3837"/>
         <source>Lista de juegos como principal</source>
         <translation>Liste over spil som standard</translation>
     </message>
@@ -1981,13 +1981,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2025"/>
-        <location filename="../../src/grlida.cpp" line="2040"/>
+        <location filename="../../src/grlida.cpp" line="2052"/>
         <source>Perspectiva</source>
         <translation>Perspektiv</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2121"/>
-        <location filename="../../src/grlida.cpp" line="2052"/>
+        <location filename="../../src/grlida.cpp" line="2064"/>
         <source>Estado</source>
         <translation>Stat</translation>
     </message>
@@ -2003,286 +2003,286 @@ Denne applikation kræver SQLite. Læs Qt SQL føreren dokumenter for mere info.
 Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1605"/>
-        <location filename="../../src/grlida.cpp" line="2033"/>
+        <location filename="../../src/grlida.cpp" line="1617"/>
+        <location filename="../../src/grlida.cpp" line="2045"/>
         <source>TÃ­tulo</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1608"/>
-        <location filename="../../src/grlida.cpp" line="2036"/>
+        <location filename="../../src/grlida.cpp" line="1620"/>
+        <location filename="../../src/grlida.cpp" line="2048"/>
         <source>CompaÃ±ia</source>
         <translation>Udgiver</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1613"/>
-        <location filename="../../src/grlida.cpp" line="2044"/>
+        <location filename="../../src/grlida.cpp" line="1625"/>
+        <location filename="../../src/grlida.cpp" line="2056"/>
         <source>AÃ±o</source>
         <translation>År</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1614"/>
+        <location filename="../../src/grlida.cpp" line="1626"/>
         <source>NÂº discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1616"/>
-        <location filename="../../src/grlida.cpp" line="2048"/>
+        <location filename="../../src/grlida.cpp" line="1628"/>
+        <location filename="../../src/grlida.cpp" line="2060"/>
         <source>GrÃ¡ficos</source>
         <translation>Grafik</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2054"/>
+        <location filename="../../src/grlida.cpp" line="2066"/>
         <source>Tipo Emu</source>
         <translation>Emu type</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2047"/>
+        <location filename="../../src/grlida.cpp" line="2059"/>
         <source>TamaÃ±o</source>
         <translation>Størrelse</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>de</source>
         <translation>den</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>NÂº juegos</source>
         <translation>Antal spil</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1537"/>
+        <location filename="../../src/grlida.cpp" line="1549"/>
         <source>InformaciÃ³n no disponible</source>
         <translation>Information er ikke tilgængelig</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2683"/>
+        <location filename="../../src/grlida.cpp" line="2705"/>
         <source>introducido el</source>
         <translation>Indtastet</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3216"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3238"/>
         <source>Si</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1606"/>
-        <location filename="../../src/grlida.cpp" line="2034"/>
+        <location filename="../../src/grlida.cpp" line="1618"/>
+        <location filename="../../src/grlida.cpp" line="2046"/>
         <source>SubtÃ­tulo</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1924"/>
+        <location filename="../../src/grlida.cpp" line="1936"/>
         <source>The file is not an XBEL version 1.0 file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Actualizaciones</source>
         <translation>Opdateringer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>No existen actualizaciones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Mostrar</source>
         <translation>Vis</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Aceptar</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2042"/>
+        <location filename="../../src/grlida.cpp" line="2054"/>
         <source>Idioma Voces</source>
         <translation>Sprog voices</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2045"/>
+        <location filename="../../src/grlida.cpp" line="2057"/>
         <source>NÂº Discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2053"/>
+        <location filename="../../src/grlida.cpp" line="2065"/>
         <source>Fecha</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3221"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3243"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3157"/>
+        <location filename="../../src/grlida.cpp" line="3179"/>
         <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3161"/>
+        <location filename="../../src/grlida.cpp" line="3183"/>
         <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3162"/>
+        <location filename="../../src/grlida.cpp" line="3184"/>
         <source>Ademas borrara lo marcado siempre y cuando este dentro del directorio del GR-lida.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3177"/>
+        <location filename="../../src/grlida.cpp" line="3199"/>
         <source>Eliminar carÃ¡tula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3181"/>
+        <location filename="../../src/grlida.cpp" line="3203"/>
         <source>Eliminar imÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3186"/>
+        <location filename="../../src/grlida.cpp" line="3208"/>
         <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3190"/>
+        <location filename="../../src/grlida.cpp" line="3212"/>
         <source>Eliminar capturas de pantalla.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3194"/>
+        <location filename="../../src/grlida.cpp" line="3216"/>
         <source>Eliminar imÃ¡genes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3198"/>
+        <location filename="../../src/grlida.cpp" line="3220"/>
         <source>Eliminar capturas de sonido.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3202"/>
+        <location filename="../../src/grlida.cpp" line="3224"/>
         <source>Eliminar capturas de video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3206"/>
+        <location filename="../../src/grlida.cpp" line="3228"/>
         <source>Eliminar archivos guardados.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3253"/>
+        <location filename="../../src/grlida.cpp" line="3275"/>
         <source>CarÃ¡tula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3260"/>
+        <location filename="../../src/grlida.cpp" line="3282"/>
         <source>ImÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3272"/>
+        <location filename="../../src/grlida.cpp" line="3294"/>
         <source>Capturas de pantalla</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3279"/>
+        <location filename="../../src/grlida.cpp" line="3301"/>
         <source>ImÃ¡genes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3287"/>
+        <location filename="../../src/grlida.cpp" line="3309"/>
         <source>Capturas de videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3313"/>
+        <location filename="../../src/grlida.cpp" line="3335"/>
         <source>ConfiguraciÃ³n de DOSBox</source>
         <translation>konfiguration DOSBox</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3331"/>
+        <location filename="../../src/grlida.cpp" line="3353"/>
         <source>ConfiguraciÃ³n de ScummVM</source>
         <translation>konfiguration ScummVM</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3339"/>
+        <location filename="../../src/grlida.cpp" line="3361"/>
         <source>ConfiguraciÃ³n de VDMSound</source>
         <translation>konfiguration VDMSound</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>El juego ha sido eliminado correctamente</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>Ha borrado</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3505"/>
+        <location filename="../../src/grlida.cpp" line="3527"/>
         <source>Ejecutar</source>
         <translation>Kør</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4816"/>
+        <location filename="../../src/grlida.cpp" line="4838"/>
         <source>Se ha producido un error al salir del proceso</source>
         <translation>Der var en fejl i processen</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4841"/>
+        <location filename="../../src/grlida.cpp" line="4863"/>
         <source>Se ha producido un error al iniciar el proceso de inicio</source>
         <translation>Der opstod en fejl, der starter opstartsprocessen</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4844"/>
+        <location filename="../../src/grlida.cpp" line="4866"/>
         <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
         <translation>Der opstod en fejl i processen, tid efter start med succes</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4847"/>
+        <location filename="../../src/grlida.cpp" line="4869"/>
         <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
         <translation>Der opstod en fejl, vent ... () Sidste gang out funktion</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4850"/>
+        <location filename="../../src/grlida.cpp" line="4872"/>
         <source>Se ha producido un error al intentar escribir en el proceso de inicio</source>
         <translation>Der opstod en fejl under forsøg på at skrive til boot-processen</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4853"/>
+        <location filename="../../src/grlida.cpp" line="4875"/>
         <source>Se ha producido un error al intentar leer en el proceso</source>
         <translation>Der opstod en fejl under forsøg på at læse i processen</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4856"/>
+        <location filename="../../src/grlida.cpp" line="4878"/>
         <source>Ha ocurrido un error desconocido</source>
         <translation>Der opstod en ukendt fejl</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3127"/>
-        <location filename="../../src/grlida.cpp" line="3388"/>
+        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3410"/>
         <source>Por favor selecciona un juego de la lista para eliminarlo</source>
         <translation>Vælg et spil fra listen for at slette</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3171"/>
         <source>Â¿Eliminar juego...?</source>
         <translation>Slet spil...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3014"/>
+        <location filename="../../src/grlida.cpp" line="3036"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>Den emulator fil blev ikke fundet.
@@ -2588,37 +2588,37 @@ Please check the media service plugins are installed.</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="825"/>
+        <location filename="../../src/dbsql.cpp" line="859"/>
         <source>Generos</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="826"/>
+        <location filename="../../src/dbsql.cpp" line="860"/>
         <source>Temas</source>
         <translation>Emner</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="827"/>
+        <location filename="../../src/dbsql.cpp" line="861"/>
         <source>Desarrolladores</source>
         <translation>Developer</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="828"/>
+        <location filename="../../src/dbsql.cpp" line="862"/>
         <source>CompaÃ±ias</source>
         <translation>Udgiver</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="829"/>
+        <location filename="../../src/dbsql.cpp" line="863"/>
         <source>AÃ±os</source>
         <translation>År</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="830"/>
+        <location filename="../../src/dbsql.cpp" line="864"/>
         <source>Idiomas</source>
         <translation>Sprog</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="849"/>
+        <location filename="../../src/dbsql.cpp" line="883"/>
         <source>Todos</source>
         <translation>Alle</translation>
     </message>
@@ -2748,11 +2748,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Selecciona un archivo</source>
         <translation>Vælg en fil</translation>
     </message>
@@ -2765,11 +2765,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Todos los archivos</source>
         <translation>Alle filer</translation>
     </message>
@@ -2794,19 +2794,19 @@ Please check the media service plugins are installed.</source>
         <translation>Ønsker du at slette denne montering?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1215"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1222"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1229"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1209"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1216"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1223"/>
         <source>Seleccionar un directorio</source>
         <translation>Vælg en mappe</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Idioma</source>
         <translation>Sprog</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
         <source>Imagen</source>
         <translation>Billede</translation>
     </message>
@@ -2816,12 +2816,12 @@ Please check the media service plugins are installed.</source>
         <translation>Som standard</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
         <source>Imagen CD</source>
         <translation>Billede CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
         <source>Imagen HD</source>
         <translation>Billede HD</translation>
     </message>
@@ -4354,121 +4354,130 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="64"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>ISO, CUE+BIN image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
         <source>Imagen ISO multiples</source>
         <translation>Multiple ISO images</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
         <source>Imagen de disco duro</source>
         <translation>Harddisk image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="68"/>
         <source>Imagen Botable</source>
         <translation>Bootable image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="70"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <source>No usar nada</source>
         <translation>Brug ikke noget</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Usar</source>
         <translation>Anvendelse</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
         <translation>Kraft ASPI layer brug. Kun Windows med ASPI-Layer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
         <translation>Automatisk Audio CD-interface</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio udtræk til Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <source>Llamadas ioctl utiliza para CD de audio</source>
         <translation>IOCTL opfordrer til Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
         <source>MCI utiliza para CD de audio</source>
         <translation>IOCTL opfordrer til Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
         <translation>Kraft SDL for CD-ROM. Fås i alle systemer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="87"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="88"/>
         <source>NO usar CD</source>
         <translation>Må ikke monteres CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="272"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="273"/>
         <source>Seleccionar un directorio</source>
         <translation>Vælg en mappe</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Todos los archivos</source>
         <translation>Alle filer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
         <source>Â¿Eliminar...?</source>
         <translation>Slet...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Ønsker du at fjerne ISO fra listen?</translation>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="397"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Ønsker du at fjerne ISO fra listen?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="398"/>
         <source>Espacio libre virtual (%1 %2)</source>
         <translation>Virtuelle frirum (%1 %2)</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>Procura no montar la Raiz del sistema operativo: ejemplo en windows seria</source>
         <translation>Prøv ikke at medtage dit OS sti i montering: et eksempel til Windows ville være</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>y en linux seria directamente</source>
         <translation>og i Linux ville det være</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="281"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="282"/>
         <source>Imagen</source>
         <translation>Billede</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="283"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="284"/>
         <source>Imagen CD</source>
         <translation>Billede CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Selecciona un archivo</source>
         <translation>Vælg en fil</translation>
     </message>
@@ -6666,69 +6675,78 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="86"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>ISO, CUE+BIN image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
         <source>Imagen ISO multiples</source>
         <translation>Multiple ISO images</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="89"/>
         <source>Imagen de disco duro</source>
         <translation>Harddisk image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="168"/>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="252"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="169"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="253"/>
         <source>Seleccionar un directorio</source>
         <translation>Vælg en mappe</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Todos los archivos</source>
         <translation>Alle filer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
         <source>Â¿Eliminar...?</source>
         <translation>Slet...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Ønsker du at fjerne ISO fra listen?</translation>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="282"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Ønsker du at fjerne ISO fra listen?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="283"/>
         <source>El ejecutable suele ser: INSTALL, si no esta seguro teclee DIR y pulsa INTRO</source>
         <translation>Programmet hedder normalt INSTALL. Hvis du er i tvivl, skriv DIR og tryk ENTER</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="347"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="355"/>
         <source>Puede que no este disponible el ejecutable del emulador.
 O el directorio de destino.</source>
         <translation>Enten emulator program filen er ikke tilgængelig,
 eller destinationsmappen er forkert.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="177"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="178"/>
         <source>Imagen</source>
         <translation>Billede</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="179"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="180"/>
         <source>Imagen CD</source>
         <translation>Billede CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Selecciona un archivo</source>
         <translation>Vælg en fil</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="131"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="132"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>Den emulator fil blev ikke fundet.
@@ -7479,6 +7497,7 @@ Tjek, om programmet virkelig er installeret.</translation>
         <translation>Label</translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="2440"/>
         <location filename="../../src/grlida_opciones.cpp" line="2490"/>
         <location filename="../../src/grlida_opciones.cpp" line="2508"/>
         <source>Config</source>
@@ -7796,6 +7815,51 @@ Tjek, om programmet virkelig er installeret.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="174"/>
+        <source>Cada veinticuatro horas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="175"/>
+        <source>Semanalmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="176"/>
+        <source>Mensualmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="202"/>
+        <location filename="../../src/grlida_opciones.cpp" line="246"/>
+        <location filename="../../src/grlida_opciones.cpp" line="283"/>
+        <location filename="../../src/grlida_opciones.cpp" line="316"/>
+        <location filename="../../src/grlida_opciones.cpp" line="342"/>
+        <location filename="../../src/grlida_opciones.cpp" line="391"/>
+        <location filename="../../src/grlida_opciones.cpp" line="498"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2427"/>
+        <source>ImÃ¡genes CategorÃ­as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="249"/>
+        <location filename="../../src/grlida_opciones.cpp" line="286"/>
+        <location filename="../../src/grlida_opciones.cpp" line="319"/>
+        <location filename="../../src/grlida_opciones.cpp" line="345"/>
+        <location filename="../../src/grlida_opciones.cpp" line="394"/>
+        <location filename="../../src/grlida_opciones.cpp" line="501"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2429"/>
+        <source>ImÃ¡genes defecto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="322"/>
+        <location filename="../../src/grlida_opciones.cpp" line="348"/>
+        <location filename="../../src/grlida_opciones.cpp" line="504"/>
+        <source>ImÃ¡genes idiomas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/grlida_opciones.cpp" line="555"/>
         <source>Thumb en JPG</source>
         <translation type="unfinished"></translation>
@@ -7953,6 +8017,13 @@ Tjek, om programmet virkelig er installeret.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2836"/>
         <source>Color de texto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="3075"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3105"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3135"/>
+        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8913,7 +8984,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     <message>
         <location filename="../../ui/update.ui" line="20"/>
         <location filename="../../ui/update.ui" line="64"/>
-        <location filename="../../src/grlida_update.cpp" line="108"/>
+        <location filename="../../src/grlida_update.cpp" line="121"/>
         <source>Actualizaciones</source>
         <translation>Opdateringer</translation>
     </message>
@@ -8938,27 +9009,27 @@ Tjek, om programmet virkelig er installeret.</translation>
         <translation>Luk</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="64"/>
+        <location filename="../../src/grlida_update.cpp" line="74"/>
         <source>Estilos o themes para el GR-lida</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Descargar</source>
         <translation>Hent</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Actualizar</source>
         <translation>Opdater</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="70"/>
+        <location filename="../../src/grlida_update.cpp" line="82"/>
         <source>Lista de compatibilidad del ScummVM</source>
         <translation>ScummVM kompatibilitetsliste</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="58"/>
+        <location filename="../../src/grlida_update.cpp" line="65"/>
         <source>Script para importar datos del juego</source>
         <translation>Script til at importere spildata</translation>
     </message>

--- a/res/idiomas/gr-lida_en_EN.ts
+++ b/res/idiomas/gr-lida_en_EN.ts
@@ -2005,12 +2005,12 @@
         <location filename="../../src/grlida.cpp" line="2202"/>
         <location filename="../../src/grlida.cpp" line="2727"/>
         <source>de</source>
-        <translation>the</translation>
+        <translation>of</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2683"/>
         <source>introducido el</source>
-        <translation>Entered the</translation>
+        <translation>Added on</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2632"/>
@@ -2279,7 +2279,7 @@ Click cancel to exit.</translation>
         <location filename="../../src/grlida.cpp" line="2202"/>
         <location filename="../../src/grlida.cpp" line="2727"/>
         <source>NÂº juegos</source>
-        <translation>Number of games</translation>
+        <translation>Game</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3014"/>
@@ -2743,7 +2743,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="829"/>
         <source>%1K memoria convencional restante</source>
-        <translation>%1K memoria convencional restante</translation>
+        <translation>%1K conventional memory left</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
@@ -3068,7 +3068,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../ui/addedit_dosbox.ui" line="30"/>
         <source>Datos generales para el DOSbox</source>
-        <translation>Opciones del VDMSound</translation>
+        <translation>General DOSBox data</translation>
     </message>
     <message>
         <location filename="../../ui/addedit_dosbox.ui" line="62"/>
@@ -3362,12 +3362,12 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../ui/addedit_dosbox.ui" line="2061"/>
         <source>Autocrear montaje</source>
-        <translation>Automatic mounting</translation>
+        <translation>Autocreate mount point</translation>
     </message>
     <message>
         <location filename="../../ui/addedit_dosbox.ui" line="2078"/>
         <source>Selecciona montaje primario</source>
-        <translation>Choose first device mounting</translation>
+        <translation>Select as primary device</translation>
     </message>
     <message utf8="true">
         <location filename="../../ui/addedit_dosbox.ui" line="2106"/>
@@ -3628,7 +3628,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../ui/addedit_juego.ui" line="404"/>
         <source>Introducido el</source>
-        <translation>Entered the</translation>
+        <translation>added on</translation>
     </message>
     <message utf8="true">
         <location filename="../../ui/addedit_juego.ui" line="414"/>
@@ -3760,7 +3760,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../ui/addedit_juego.ui" line="184"/>
         <source>Idioma voces:</source>
-        <translation>Language Voices:</translation>
+        <translation>Voices:</translation>
     </message>
     <message>
         <location filename="../../ui/addedit_juego.ui" line="397"/>
@@ -8356,7 +8356,7 @@ Check if the program is really installed.</translation>
     <message utf8="true">
         <location filename="../../ui/opciones.ui" line="871"/>
         <source>Guardar archivo de configuración del DOSBox, si esta desactivado se genera al ejecutar el juego.</source>
-        <translation>Save DOSBox configuration file, if disabled, is generated when the game is executed.</translation>
+        <translation>Save DOSBox configuration file; if disabled generate when game is executed.</translation>
     </message>
     <message>
         <location filename="../../ui/opciones.ui" line="1110"/>
@@ -9027,7 +9027,7 @@ Check if the program is really installed.</translation>
     <message>
         <location filename="../../ui/wizard_dosbox.ui" line="630"/>
         <source>Templates profiles:</source>
-        <translation></translation>
+        <translation>Profile template:</translation>
     </message>
     <message>
         <location filename="../../ui/wizard_dosbox.ui" line="490"/>

--- a/res/idiomas/gr-lida_en_EN.ts
+++ b/res/idiomas/gr-lida_en_EN.ts
@@ -4355,7 +4355,7 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="64"/>
         <source>Imagen de disquete multiples</source>
-        <translation type="unfinished"></translation>
+        <translation>Multiple floppy disk images</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
@@ -4445,11 +4445,7 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
         <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation type="obsolete">Do you want to remove the ISO from the list?</translation>
+        <translation>Do you want to remove the ISO/IMA/IMG from the list?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="398"/>
@@ -6680,7 +6676,7 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="86"/>
         <source>Imagen de disquete multiples</source>
-        <translation type="unfinished"></translation>
+        <translation>Multiple floppy disk images</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
@@ -6716,11 +6712,7 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
         <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation type="obsolete">Do you want to remove the ISO from the list?</translation>
+        <translation>Do you want to remove the ISO/IMA/IMG from the list?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="283"/>
@@ -7489,7 +7481,7 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3105"/>
         <location filename="../../src/grlida_opciones.cpp" line="3135"/>
         <source>Â¿Deseas eliminar la extensiÃ³n?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to remove this extension?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1193"/>
@@ -7861,17 +7853,17 @@ Check if the program is really installed.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="174"/>
         <source>Cada veinticuatro horas</source>
-        <translation type="unfinished"></translation>
+        <translation>Every 24 hours</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="175"/>
         <source>Semanalmente</source>
-        <translation type="unfinished"></translation>
+        <translation>Weekly</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="176"/>
         <source>Mensualmente</source>
-        <translation type="unfinished"></translation>
+        <translation>Monthly</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="202"/>
@@ -7883,7 +7875,7 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="498"/>
         <location filename="../../src/grlida_opciones.cpp" line="2427"/>
         <source>ImÃ¡genes CategorÃ­as</source>
-        <translation type="unfinished"></translation>
+        <translation>Category icons</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="249"/>
@@ -7894,14 +7886,14 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="501"/>
         <location filename="../../src/grlida_opciones.cpp" line="2429"/>
         <source>ImÃ¡genes defecto</source>
-        <translation type="unfinished"></translation>
+        <translation>defecto icons</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="322"/>
         <location filename="../../src/grlida_opciones.cpp" line="348"/>
         <location filename="../../src/grlida_opciones.cpp" line="504"/>
         <source>ImÃ¡genes idiomas</source>
-        <translation type="unfinished"></translation>
+        <translation>Language icons</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="555"/>
@@ -8725,7 +8717,7 @@ Check if the program is really installed.</translation>
     <message utf8="true">
         <location filename="../../ui/opciones.ui" line="404"/>
         <source>Comprobación cada</source>
-        <translation>Checking every</translation>
+        <translation>Check</translation>
     </message>
     <message>
         <location filename="../../ui/opciones.ui" line="421"/>

--- a/res/idiomas/gr-lida_en_EN.ts
+++ b/res/idiomas/gr-lida_en_EN.ts
@@ -241,188 +241,188 @@
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="978"/>
+        <location filename="../../src/funciones.cpp" line="980"/>
         <source>CarÃ¡tula frontal</source>
         <translation>Front cover</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="979"/>
+        <location filename="../../src/funciones.cpp" line="981"/>
         <source>Detalles del juego</source>
         <translation>Game Details</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="980"/>
+        <location filename="../../src/funciones.cpp" line="982"/>
         <source>CalificaciÃ³n</source>
         <translation>Qualification</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="981"/>
+        <location filename="../../src/funciones.cpp" line="983"/>
         <source>Otros datos</source>
         <translation>Other data</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="982"/>
+        <location filename="../../src/funciones.cpp" line="984"/>
         <source>Subido por</source>
         <translation>Uploaded by</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="983"/>
+        <location filename="../../src/funciones.cpp" line="985"/>
         <source>SubtÃ­tulo</source>
         <translation>Subtitle</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="984"/>
+        <location filename="../../src/funciones.cpp" line="986"/>
         <source>Publicado por</source>
         <translation>Publisher by</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="985"/>
+        <location filename="../../src/funciones.cpp" line="987"/>
         <source>Desarrollado por</source>
         <translation>Developer by</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="986"/>
+        <location filename="../../src/funciones.cpp" line="988"/>
         <source>Publicado</source>
         <translation>Published</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="987"/>
+        <location filename="../../src/funciones.cpp" line="989"/>
         <source>Edad recomendada</source>
         <translation>Recommended age</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="988"/>
+        <location filename="../../src/funciones.cpp" line="990"/>
         <source>Idioma</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="989"/>
+        <location filename="../../src/funciones.cpp" line="991"/>
         <source>Idioma voces</source>
         <translation>Language voices</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="990"/>
+        <location filename="../../src/funciones.cpp" line="992"/>
         <source>Formato</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="991"/>
+        <location filename="../../src/funciones.cpp" line="993"/>
         <source>Genero</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="992"/>
+        <location filename="../../src/funciones.cpp" line="994"/>
         <source>Tema</source>
         <translation>Theme</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="993"/>
+        <location filename="../../src/funciones.cpp" line="995"/>
         <source>Grupo</source>
         <translation>Group</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="994"/>
+        <location filename="../../src/funciones.cpp" line="996"/>
         <source>Perspectiva</source>
         <translation>Perspective</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="995"/>
+        <location filename="../../src/funciones.cpp" line="997"/>
         <source>Sistema operativo</source>
         <translation>SO</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="996"/>
+        <location filename="../../src/funciones.cpp" line="998"/>
         <source>Favorito</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>Joystick</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>GamePad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="998"/>
+        <location filename="../../src/funciones.cpp" line="1000"/>
         <source>AÃ±adido el</source>
         <translation>Added the</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="999"/>
+        <location filename="../../src/funciones.cpp" line="1001"/>
         <source>GrÃ¡ficos</source>
         <translation>Graphics</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1000"/>
+        <location filename="../../src/funciones.cpp" line="1002"/>
         <source>Sonido</source>
         <translation>Sound</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1001"/>
+        <location filename="../../src/funciones.cpp" line="1003"/>
         <source>Jugabilidad</source>
         <translation>Playability</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1002"/>
+        <location filename="../../src/funciones.cpp" line="1004"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1003"/>
+        <location filename="../../src/funciones.cpp" line="1005"/>
         <source>Estado</source>
         <translation>State</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1004"/>
+        <location filename="../../src/funciones.cpp" line="1006"/>
         <source>Tipo Emu</source>
         <translation>Emu type</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1005"/>
+        <location filename="../../src/funciones.cpp" line="1007"/>
         <source>DescripciÃ³n</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1006"/>
+        <location filename="../../src/funciones.cpp" line="1008"/>
         <source>Rating</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1007"/>
+        <location filename="../../src/funciones.cpp" line="1009"/>
         <source>NÂº discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1011"/>
+        <location filename="../../src/funciones.cpp" line="1013"/>
         <source>TÃ­tulo</source>
         <translation>Title</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1012"/>
+        <location filename="../../src/funciones.cpp" line="1014"/>
         <source>TÃ­tulo album</source>
         <translation>Title album</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1013"/>
+        <location filename="../../src/funciones.cpp" line="1015"/>
         <source>Artista album</source>
         <translation>Album artist</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1928"/>
+        <location filename="../../src/funciones.cpp" line="1930"/>
         <source>ConfiguraciÃ³n por defecto</source>
         <translation>Default configuration</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1933"/>
-        <location filename="../../src/funciones.cpp" line="1934"/>
+        <location filename="../../src/funciones.cpp" line="1935"/>
+        <location filename="../../src/funciones.cpp" line="1936"/>
         <source>Importar desde un archivo</source>
         <translation>Import from file</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1960"/>
+        <location filename="../../src/funciones.cpp" line="1962"/>
         <source>exterior</source>
         <translation>external</translation>
     </message>
@@ -876,14 +876,14 @@
 <context>
     <name>GrLida</name>
     <message>
-        <location filename="../../src/grlida.cpp" line="1604"/>
+        <location filename="../../src/grlida.cpp" line="1616"/>
         <source>Por ID</source>
         <translation>By ID</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1985"/>
-        <location filename="../../src/grlida.cpp" line="1607"/>
-        <location filename="../../src/grlida.cpp" line="2035"/>
+        <location filename="../../src/grlida.cpp" line="1619"/>
+        <location filename="../../src/grlida.cpp" line="2047"/>
         <source>Genero</source>
         <translation>Genre</translation>
     </message>
@@ -1403,9 +1403,9 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1470"/>
-        <location filename="../../src/grlida.cpp" line="3835"/>
-        <location filename="../../src/grlida.cpp" line="3836"/>
-        <location filename="../../src/grlida.cpp" line="3837"/>
+        <location filename="../../src/grlida.cpp" line="3857"/>
+        <location filename="../../src/grlida.cpp" line="3858"/>
+        <location filename="../../src/grlida.cpp" line="3859"/>
         <source>PictureFlow como principal</source>
         <translation>PictureFlow set as main</translation>
     </message>
@@ -1425,7 +1425,7 @@
         <location filename="../../ui/grlida.ui" line="1679"/>
         <location filename="../../ui/grlida.ui" line="1769"/>
         <location filename="../../ui/grlida.ui" line="1772"/>
-        <location filename="../../src/grlida.cpp" line="3303"/>
+        <location filename="../../src/grlida.cpp" line="3325"/>
         <source>Archivos</source>
         <translation>Files</translation>
     </message>
@@ -1594,7 +1594,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1969"/>
-        <location filename="../../src/grlida.cpp" line="2032"/>
+        <location filename="../../src/grlida.cpp" line="2044"/>
         <source>Icono</source>
         <translation>Icons</translation>
     </message>
@@ -1605,8 +1605,8 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2001"/>
-        <location filename="../../src/grlida.cpp" line="1609"/>
-        <location filename="../../src/grlida.cpp" line="2037"/>
+        <location filename="../../src/grlida.cpp" line="1621"/>
+        <location filename="../../src/grlida.cpp" line="2049"/>
         <source>Desarrollador</source>
         <translation>Developer</translation>
     </message>
@@ -1630,34 +1630,34 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2009"/>
-        <location filename="../../src/grlida.cpp" line="1610"/>
-        <location filename="../../src/grlida.cpp" line="2038"/>
+        <location filename="../../src/grlida.cpp" line="1622"/>
+        <location filename="../../src/grlida.cpp" line="2050"/>
         <source>Tema</source>
         <translation>Theme</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2017"/>
-        <location filename="../../src/grlida.cpp" line="2039"/>
+        <location filename="../../src/grlida.cpp" line="2051"/>
         <source>Grupo</source>
         <translation>Group</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2033"/>
-        <location filename="../../src/grlida.cpp" line="1611"/>
-        <location filename="../../src/grlida.cpp" line="2041"/>
+        <location filename="../../src/grlida.cpp" line="1623"/>
+        <location filename="../../src/grlida.cpp" line="2053"/>
         <source>Idioma</source>
         <translation>Language</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2049"/>
-        <location filename="../../src/grlida.cpp" line="1612"/>
-        <location filename="../../src/grlida.cpp" line="2043"/>
+        <location filename="../../src/grlida.cpp" line="1624"/>
+        <location filename="../../src/grlida.cpp" line="2055"/>
         <source>Formato</source>
         <translation>Format</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2073"/>
-        <location filename="../../src/grlida.cpp" line="2046"/>
+        <location filename="../../src/grlida.cpp" line="2058"/>
         <source>Sistema</source>
         <translation>OS</translation>
     </message>
@@ -1668,13 +1668,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2170"/>
-        <location filename="../../src/grlida.cpp" line="2057"/>
+        <location filename="../../src/grlida.cpp" line="2069"/>
         <source>Edad</source>
         <translation>Age</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2178"/>
-        <location filename="../../src/grlida.cpp" line="2058"/>
+        <location filename="../../src/grlida.cpp" line="2070"/>
         <source>Usuario</source>
         <translation>Username</translation>
     </message>
@@ -1788,7 +1788,7 @@
         <translation>Has files / covers</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3295"/>
+        <location filename="../../src/grlida.cpp" line="3317"/>
         <source>Capturas de sonidos</source>
         <translation>Sound captures</translation>
     </message>
@@ -1835,48 +1835,48 @@
         <translation>&amp;Restore</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1615"/>
+        <location filename="../../src/grlida.cpp" line="1627"/>
         <source>Sistema OS</source>
         <translation>OS</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2097"/>
-        <location filename="../../src/grlida.cpp" line="1617"/>
-        <location filename="../../src/grlida.cpp" line="2049"/>
+        <location filename="../../src/grlida.cpp" line="1629"/>
+        <location filename="../../src/grlida.cpp" line="2061"/>
         <source>Sonido</source>
         <translation>Sound</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2105"/>
-        <location filename="../../src/grlida.cpp" line="1618"/>
-        <location filename="../../src/grlida.cpp" line="2050"/>
+        <location filename="../../src/grlida.cpp" line="1630"/>
+        <location filename="../../src/grlida.cpp" line="2062"/>
         <source>Jugabilidad</source>
         <translation>Playability</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2113"/>
-        <location filename="../../src/grlida.cpp" line="1619"/>
-        <location filename="../../src/grlida.cpp" line="2051"/>
+        <location filename="../../src/grlida.cpp" line="1631"/>
+        <location filename="../../src/grlida.cpp" line="2063"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1620"/>
-        <location filename="../../src/grlida.cpp" line="2295"/>
+        <location filename="../../src/grlida.cpp" line="1632"/>
+        <location filename="../../src/grlida.cpp" line="2307"/>
         <source>Tipo emulador</source>
         <translation>Emulation type</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2151"/>
-        <location filename="../../src/grlida.cpp" line="1621"/>
-        <location filename="../../src/grlida.cpp" line="2055"/>
+        <location filename="../../src/grlida.cpp" line="1633"/>
+        <location filename="../../src/grlida.cpp" line="2067"/>
         <source>Favorito</source>
         <translation>Favorite</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2162"/>
-        <location filename="../../src/grlida.cpp" line="1622"/>
-        <location filename="../../src/grlida.cpp" line="2056"/>
+        <location filename="../../src/grlida.cpp" line="1634"/>
+        <location filename="../../src/grlida.cpp" line="2068"/>
         <source>Rating</source>
         <translation></translation>
     </message>
@@ -1886,12 +1886,12 @@
         <translation>by</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1626"/>
+        <location filename="../../src/grlida.cpp" line="1638"/>
         <source>Ascendente</source>
         <translation>Ascending</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1627"/>
+        <location filename="../../src/grlida.cpp" line="1639"/>
         <source>Descendente</source>
         <translation>Descending</translation>
     </message>
@@ -1901,17 +1901,17 @@
         <translation>Sort</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2289"/>
+        <location filename="../../src/grlida.cpp" line="2301"/>
         <source>Todos</source>
         <translation>All</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2290"/>
+        <location filename="../../src/grlida.cpp" line="2302"/>
         <source>Favoritos</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2291"/>
+        <location filename="../../src/grlida.cpp" line="2303"/>
         <source>Originales</source>
         <translation>Original</translation>
     </message>
@@ -1921,36 +1921,36 @@
         <translation>Error when opening database</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2526"/>
+        <location filename="../../src/grlida.cpp" line="2540"/>
         <source>Datos</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2558"/>
+        <location filename="../../src/grlida.cpp" line="2572"/>
         <source>Otro emulador</source>
         <translation>Another emulator</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3194"/>
+        <location filename="../../src/grlida.cpp" line="3216"/>
         <source>Eliminar imÃ¡genes.</source>
         <translation>Remove images.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3807"/>
-        <location filename="../../src/grlida.cpp" line="3808"/>
-        <location filename="../../src/grlida.cpp" line="3809"/>
+        <location filename="../../src/grlida.cpp" line="3829"/>
+        <location filename="../../src/grlida.cpp" line="3830"/>
+        <location filename="../../src/grlida.cpp" line="3831"/>
         <source>Ver lista de juegos</source>
         <translation>Show list games</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3810"/>
+        <location filename="../../src/grlida.cpp" line="3832"/>
         <source>Lista de juegos</source>
         <translation>List games</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3813"/>
-        <location filename="../../src/grlida.cpp" line="3814"/>
-        <location filename="../../src/grlida.cpp" line="3815"/>
+        <location filename="../../src/grlida.cpp" line="3835"/>
+        <location filename="../../src/grlida.cpp" line="3836"/>
+        <location filename="../../src/grlida.cpp" line="3837"/>
         <source>Lista de juegos como principal</source>
         <translation>List of games set as main</translation>
     </message>
@@ -1961,7 +1961,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2025"/>
-        <location filename="../../src/grlida.cpp" line="2040"/>
+        <location filename="../../src/grlida.cpp" line="2052"/>
         <source>Perspectiva</source>
         <translation>Perspective</translation>
     </message>
@@ -1992,225 +1992,225 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2121"/>
-        <location filename="../../src/grlida.cpp" line="2052"/>
+        <location filename="../../src/grlida.cpp" line="2064"/>
         <source>Estado</source>
         <translation>State</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2054"/>
+        <location filename="../../src/grlida.cpp" line="2066"/>
         <source>Tipo Emu</source>
         <translation>Emu type</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>de</source>
         <translation>of</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2683"/>
+        <location filename="../../src/grlida.cpp" line="2705"/>
         <source>introducido el</source>
         <translation>Added on</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3216"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3238"/>
         <source>Si</source>
         <translation>Yes</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1924"/>
+        <location filename="../../src/grlida.cpp" line="1936"/>
         <source>The file is not an XBEL version 1.0 file.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Actualizaciones</source>
         <translation>Updates</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>No existen actualizaciones.</source>
         <translation>There are no updates.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Mostrar</source>
         <translation>Show</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Aceptar</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2042"/>
+        <location filename="../../src/grlida.cpp" line="2054"/>
         <source>Idioma Voces</source>
         <translation>Language Voices</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2053"/>
+        <location filename="../../src/grlida.cpp" line="2065"/>
         <source>Fecha</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3221"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3243"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3171"/>
         <source>Â¿Eliminar juego...?</source>
         <translation>Delete game ...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3157"/>
+        <location filename="../../src/grlida.cpp" line="3179"/>
         <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation>Do you really want to delete this game from the database?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3161"/>
+        <location filename="../../src/grlida.cpp" line="3183"/>
         <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
         <translation>If it is DOSBox or VDMSound, the configuration file is also deleted.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3162"/>
+        <location filename="../../src/grlida.cpp" line="3184"/>
         <source>Ademas borrara lo marcado siempre y cuando este dentro del directorio del GR-lida.</source>
         <translation>It will also erase the marked as long as it is within the GR-lida directory.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3177"/>
+        <location filename="../../src/grlida.cpp" line="3199"/>
         <source>Eliminar carÃ¡tula thumbs.</source>
         <translation>Remove cover thumbs.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3181"/>
+        <location filename="../../src/grlida.cpp" line="3203"/>
         <source>Eliminar imÃ¡genes de la caja.</source>
         <translation>Remove images from the box.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3186"/>
+        <location filename="../../src/grlida.cpp" line="3208"/>
         <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation>Cover front, back, left side, right, up, down.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3190"/>
+        <location filename="../../src/grlida.cpp" line="3212"/>
         <source>Eliminar capturas de pantalla.</source>
         <translation>Delete screenshots.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3198"/>
+        <location filename="../../src/grlida.cpp" line="3220"/>
         <source>Eliminar capturas de sonido.</source>
         <translation>Remove sound captures.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3202"/>
+        <location filename="../../src/grlida.cpp" line="3224"/>
         <source>Eliminar capturas de video.</source>
         <translation>Delete video captures.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3206"/>
+        <location filename="../../src/grlida.cpp" line="3228"/>
         <source>Eliminar archivos guardados.</source>
         <translation>Delete saved files.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3253"/>
+        <location filename="../../src/grlida.cpp" line="3275"/>
         <source>CarÃ¡tula</source>
         <translation>Cover</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3260"/>
+        <location filename="../../src/grlida.cpp" line="3282"/>
         <source>ImÃ¡genes de la caja.</source>
         <translation>Pictures of the box.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3272"/>
+        <location filename="../../src/grlida.cpp" line="3294"/>
         <source>Capturas de pantalla</source>
         <translation>Screenshots</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3279"/>
+        <location filename="../../src/grlida.cpp" line="3301"/>
         <source>ImÃ¡genes del juego</source>
         <translation>Images of the game</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3287"/>
+        <location filename="../../src/grlida.cpp" line="3309"/>
         <source>Capturas de videos</source>
         <translation>Video captures</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3313"/>
+        <location filename="../../src/grlida.cpp" line="3335"/>
         <source>ConfiguraciÃ³n de DOSBox</source>
         <translation>Configuration of DOSBox</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3331"/>
+        <location filename="../../src/grlida.cpp" line="3353"/>
         <source>ConfiguraciÃ³n de ScummVM</source>
         <translation>Configuration of ScummVM</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3339"/>
+        <location filename="../../src/grlida.cpp" line="3361"/>
         <source>ConfiguraciÃ³n de VDMSound</source>
         <translation>Configuration of VDMSound</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>El juego ha sido eliminado correctamente</source>
         <translation>The game has been removed correctly</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>Ha borrado</source>
         <translation>Has erased</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3505"/>
+        <location filename="../../src/grlida.cpp" line="3527"/>
         <source>Ejecutar</source>
         <translation>Run</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4816"/>
+        <location filename="../../src/grlida.cpp" line="4838"/>
         <source>Se ha producido un error al salir del proceso</source>
         <translation>There was an error out of the process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4841"/>
+        <location filename="../../src/grlida.cpp" line="4863"/>
         <source>Se ha producido un error al iniciar el proceso de inicio</source>
         <translation>There was an error starting the boot process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4844"/>
+        <location filename="../../src/grlida.cpp" line="4866"/>
         <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
         <translation>An error occurred in the process, time after successfully starting</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4847"/>
+        <location filename="../../src/grlida.cpp" line="4869"/>
         <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
         <translation>An error has occurred, waitFor ... () Last function the timeout</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4850"/>
+        <location filename="../../src/grlida.cpp" line="4872"/>
         <source>Se ha producido un error al intentar escribir en el proceso de inicio</source>
         <translation>There was an error while trying to write to the boot process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4853"/>
+        <location filename="../../src/grlida.cpp" line="4875"/>
         <source>Se ha producido un error al intentar leer en el proceso</source>
         <translation>There was an error while trying to read in the process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4856"/>
+        <location filename="../../src/grlida.cpp" line="4878"/>
         <source>Ha ocurrido un error desconocido</source>
         <translation>There was an unknown error</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3127"/>
-        <location filename="../../src/grlida.cpp" line="3388"/>
+        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3410"/>
         <source>Por favor selecciona un juego de la lista para eliminarlo</source>
         <translation>Please select a game from the list to delete</translation>
     </message>
@@ -2226,63 +2226,63 @@ This application needs SQLite support. See the Qt SQL driver documentation for m
 Click cancel to exit.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1537"/>
+        <location filename="../../src/grlida.cpp" line="1549"/>
         <source>InformaciÃ³n no disponible</source>
         <translation>Information not available</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1605"/>
-        <location filename="../../src/grlida.cpp" line="2033"/>
+        <location filename="../../src/grlida.cpp" line="1617"/>
+        <location filename="../../src/grlida.cpp" line="2045"/>
         <source>TÃ­tulo</source>
         <translation>Title</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1606"/>
-        <location filename="../../src/grlida.cpp" line="2034"/>
+        <location filename="../../src/grlida.cpp" line="1618"/>
+        <location filename="../../src/grlida.cpp" line="2046"/>
         <source>SubtÃ­tulo</source>
         <translation>Subtitle</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1608"/>
-        <location filename="../../src/grlida.cpp" line="2036"/>
+        <location filename="../../src/grlida.cpp" line="1620"/>
+        <location filename="../../src/grlida.cpp" line="2048"/>
         <source>CompaÃ±ia</source>
         <translation>Publisher</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1613"/>
-        <location filename="../../src/grlida.cpp" line="2044"/>
+        <location filename="../../src/grlida.cpp" line="1625"/>
+        <location filename="../../src/grlida.cpp" line="2056"/>
         <source>AÃ±o</source>
         <translation>Year</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1614"/>
+        <location filename="../../src/grlida.cpp" line="1626"/>
         <source>NÂº discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1616"/>
-        <location filename="../../src/grlida.cpp" line="2048"/>
+        <location filename="../../src/grlida.cpp" line="1628"/>
+        <location filename="../../src/grlida.cpp" line="2060"/>
         <source>GrÃ¡ficos</source>
         <translation>Graphics</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2045"/>
+        <location filename="../../src/grlida.cpp" line="2057"/>
         <source>NÂº Discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2047"/>
+        <location filename="../../src/grlida.cpp" line="2059"/>
         <source>TamaÃ±o</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>NÂº juegos</source>
         <translation>Game</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3014"/>
+        <location filename="../../src/grlida.cpp" line="3036"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>The emulator binary was not found.
@@ -2588,37 +2588,37 @@ Please check the media service plugins are installed.</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="825"/>
+        <location filename="../../src/dbsql.cpp" line="859"/>
         <source>Generos</source>
         <translation>Genres</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="826"/>
+        <location filename="../../src/dbsql.cpp" line="860"/>
         <source>Temas</source>
         <translation>Themes</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="827"/>
+        <location filename="../../src/dbsql.cpp" line="861"/>
         <source>Desarrolladores</source>
         <translation>Developers</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="828"/>
+        <location filename="../../src/dbsql.cpp" line="862"/>
         <source>CompaÃ±ias</source>
         <translation>Publisher</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="829"/>
+        <location filename="../../src/dbsql.cpp" line="863"/>
         <source>AÃ±os</source>
         <translation>Year</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="830"/>
+        <location filename="../../src/dbsql.cpp" line="864"/>
         <source>Idiomas</source>
         <translation>Languages</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="849"/>
+        <location filename="../../src/dbsql.cpp" line="883"/>
         <source>Todos</source>
         <translation>All</translation>
     </message>
@@ -2748,11 +2748,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Selecciona un archivo</source>
         <translation>Select a file</translation>
     </message>
@@ -2763,19 +2763,19 @@ Please check the media service plugins are installed.</source>
         <translation>Executable</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1215"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1222"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1229"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1209"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1216"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1223"/>
         <source>Seleccionar un directorio</source>
         <translation>Select a folder</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Idioma</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
         <source>Imagen</source>
         <translation>Image</translation>
     </message>
@@ -2787,11 +2787,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Todos los archivos</source>
         <translation>All files</translation>
     </message>
@@ -2816,12 +2816,12 @@ Please check the media service plugins are installed.</source>
         <translation>Do you want to delete this mount?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
         <source>Imagen CD</source>
         <translation>CD Image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
         <source>Imagen HD</source>
         <translation>HD Image</translation>
     </message>
@@ -4354,121 +4354,130 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="64"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>ISO, CUE+BIN image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
         <source>Imagen ISO multiples</source>
         <translation>Multiple ISO images</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
         <source>Imagen de disco duro</source>
         <translation>Harddisk image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="68"/>
         <source>Imagen Botable</source>
         <translation>Bootable image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="70"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <source>No usar nada</source>
         <translation>Don&apos;t use anything</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Usar</source>
         <translation>Use</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
         <translation>Force the use of the ASPI layer. Only on Windows with an ASPI-Layer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
         <translation>Automatic selection of CD audio interface</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio extraction used for audio CDs</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <source>Llamadas ioctl utiliza para CD de audio</source>
         <translation>IOCTL calls for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
         <source>MCI utiliza para CD de audio</source>
         <translation>Use MCI for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
         <translation>Force the use of SDLs for the CD-ROM. Valid for all systems</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="87"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="88"/>
         <source>NO usar CD</source>
         <translation>Don&apos;t mount CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="272"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="273"/>
         <source>Seleccionar un directorio</source>
         <translation>Select a folder</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Todos los archivos</source>
         <translation>All files</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
         <source>Â¿Eliminar...?</source>
         <translation>Delete?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Do you want to remove the ISO from the list?</translation>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="397"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Do you want to remove the ISO from the list?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="398"/>
         <source>Espacio libre virtual (%1 %2)</source>
         <translation>Virtual free space (%1 %2)</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>Procura no montar la Raiz del sistema operativo: ejemplo en windows seria</source>
         <translation>Try not to include your OS path in the mounting: an example for Windows would be</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>y en linux seria directamente</source>
         <translation>and in Linux it would be</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="281"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="282"/>
         <source>Imagen</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="283"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="284"/>
         <source>Imagen CD</source>
         <translation>Image CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Selecciona un archivo</source>
         <translation>Select a folder</translation>
     </message>
@@ -6670,69 +6679,78 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="86"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>ISO, CUE+BIN image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
         <source>Imagen ISO multiples</source>
         <translation>Multiple ISO images</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="89"/>
         <source>Imagen de disco duro</source>
         <translation>Harddisk image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="168"/>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="252"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="169"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="253"/>
         <source>Seleccionar un directorio</source>
         <translation>Select a folder</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Todos los archivos</source>
         <translation>All files</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
         <source>Â¿Eliminar...?</source>
         <translation>Delete?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Do you want to remove the ISO from the list?</translation>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="282"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Do you want to remove the ISO from the list?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="283"/>
         <source>El ejecutable suele ser: INSTALL, si no esta seguro teclee DIR y pulsa INTRO</source>
         <translation>The program name is usually INSTALL. If you are unsure, type DIR and press ENTER</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="347"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="355"/>
         <source>Puede que no este disponible el ejecutable del emulador.
 O el directorio de destino.</source>
         <translation>Either the emulator program file is not available, 
 or the destination folder is wrong.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="177"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="178"/>
         <source>Imagen</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="179"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="180"/>
         <source>Imagen CD</source>
         <translation>Image CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Selecciona un archivo</source>
         <translation>Select a file</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="131"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="132"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>The emulator binary was not found.
@@ -7467,6 +7485,13 @@ Check if the program is really installed.</translation>
         <translation>Already exists</translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="3075"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3105"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3135"/>
+        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/grlida_opciones.cpp" line="1193"/>
         <location filename="../../src/grlida_opciones.cpp" line="1456"/>
         <source>Debes poner una etiqueta.</source>
@@ -7562,6 +7587,7 @@ Check if the program is really installed.</translation>
         <translation>Label</translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="2440"/>
         <location filename="../../src/grlida_opciones.cpp" line="2490"/>
         <location filename="../../src/grlida_opciones.cpp" line="2508"/>
         <source>Config</source>
@@ -7831,6 +7857,51 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="510"/>
         <source>Icono del juego</source>
         <translation>Game icon</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="174"/>
+        <source>Cada veinticuatro horas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="175"/>
+        <source>Semanalmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="176"/>
+        <source>Mensualmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="202"/>
+        <location filename="../../src/grlida_opciones.cpp" line="246"/>
+        <location filename="../../src/grlida_opciones.cpp" line="283"/>
+        <location filename="../../src/grlida_opciones.cpp" line="316"/>
+        <location filename="../../src/grlida_opciones.cpp" line="342"/>
+        <location filename="../../src/grlida_opciones.cpp" line="391"/>
+        <location filename="../../src/grlida_opciones.cpp" line="498"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2427"/>
+        <source>ImÃ¡genes CategorÃ­as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="249"/>
+        <location filename="../../src/grlida_opciones.cpp" line="286"/>
+        <location filename="../../src/grlida_opciones.cpp" line="319"/>
+        <location filename="../../src/grlida_opciones.cpp" line="345"/>
+        <location filename="../../src/grlida_opciones.cpp" line="394"/>
+        <location filename="../../src/grlida_opciones.cpp" line="501"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2429"/>
+        <source>ImÃ¡genes defecto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="322"/>
+        <location filename="../../src/grlida_opciones.cpp" line="348"/>
+        <location filename="../../src/grlida_opciones.cpp" line="504"/>
+        <source>ImÃ¡genes idiomas</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="555"/>
@@ -8921,7 +8992,7 @@ Check if the program is really installed.</translation>
     <message>
         <location filename="../../ui/update.ui" line="20"/>
         <location filename="../../ui/update.ui" line="64"/>
-        <location filename="../../src/grlida_update.cpp" line="108"/>
+        <location filename="../../src/grlida_update.cpp" line="121"/>
         <source>Actualizaciones</source>
         <translation>Updates</translation>
     </message>
@@ -8946,27 +9017,27 @@ Check if the program is really installed.</translation>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="64"/>
+        <location filename="../../src/grlida_update.cpp" line="74"/>
         <source>Estilos o themes para el GR-lida</source>
         <translation>Styles or themes for the GR-lida</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Descargar</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Actualizar</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="70"/>
+        <location filename="../../src/grlida_update.cpp" line="82"/>
         <source>Lista de compatibilidad del ScummVM</source>
         <translation>ScummVM compatibility list</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="58"/>
+        <location filename="../../src/grlida_update.cpp" line="65"/>
         <source>Script para importar datos del juego</source>
         <translation>Script to import game data</translation>
     </message>

--- a/res/idiomas/gr-lida_es_ES.ts
+++ b/res/idiomas/gr-lida_es_ES.ts
@@ -241,188 +241,188 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="978"/>
+        <location filename="../../src/funciones.cpp" line="980"/>
         <source>CarÃ¡tula frontal</source>
         <translation>Carátula frontal</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="979"/>
+        <location filename="../../src/funciones.cpp" line="981"/>
         <source>Detalles del juego</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="980"/>
+        <location filename="../../src/funciones.cpp" line="982"/>
         <source>CalificaciÃ³n</source>
         <translation>Calificación</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="981"/>
+        <location filename="../../src/funciones.cpp" line="983"/>
         <source>Otros datos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="982"/>
+        <location filename="../../src/funciones.cpp" line="984"/>
         <source>Subido por</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="983"/>
+        <location filename="../../src/funciones.cpp" line="985"/>
         <source>SubtÃ­tulo</source>
         <translation>Subtítulo</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="984"/>
+        <location filename="../../src/funciones.cpp" line="986"/>
         <source>Publicado por</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="985"/>
+        <location filename="../../src/funciones.cpp" line="987"/>
         <source>Desarrollado por</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="986"/>
+        <location filename="../../src/funciones.cpp" line="988"/>
         <source>Publicado</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="987"/>
+        <location filename="../../src/funciones.cpp" line="989"/>
         <source>Edad recomendada</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="988"/>
+        <location filename="../../src/funciones.cpp" line="990"/>
         <source>Idioma</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="989"/>
+        <location filename="../../src/funciones.cpp" line="991"/>
         <source>Idioma voces</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="990"/>
+        <location filename="../../src/funciones.cpp" line="992"/>
         <source>Formato</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="991"/>
+        <location filename="../../src/funciones.cpp" line="993"/>
         <source>Genero</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="992"/>
+        <location filename="../../src/funciones.cpp" line="994"/>
         <source>Tema</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="993"/>
+        <location filename="../../src/funciones.cpp" line="995"/>
         <source>Grupo</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="994"/>
+        <location filename="../../src/funciones.cpp" line="996"/>
         <source>Perspectiva</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="995"/>
+        <location filename="../../src/funciones.cpp" line="997"/>
         <source>Sistema operativo</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="996"/>
+        <location filename="../../src/funciones.cpp" line="998"/>
         <source>Favorito</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>Joystick</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>GamePad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="998"/>
+        <location filename="../../src/funciones.cpp" line="1000"/>
         <source>AÃ±adido el</source>
         <translation>Añadido el</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="999"/>
+        <location filename="../../src/funciones.cpp" line="1001"/>
         <source>GrÃ¡ficos</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1000"/>
+        <location filename="../../src/funciones.cpp" line="1002"/>
         <source>Sonido</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1001"/>
+        <location filename="../../src/funciones.cpp" line="1003"/>
         <source>Jugabilidad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1002"/>
+        <location filename="../../src/funciones.cpp" line="1004"/>
         <source>Original</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1003"/>
+        <location filename="../../src/funciones.cpp" line="1005"/>
         <source>Estado</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1004"/>
+        <location filename="../../src/funciones.cpp" line="1006"/>
         <source>Tipo Emu</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1005"/>
+        <location filename="../../src/funciones.cpp" line="1007"/>
         <source>DescripciÃ³n</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1006"/>
+        <location filename="../../src/funciones.cpp" line="1008"/>
         <source>Rating</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1007"/>
+        <location filename="../../src/funciones.cpp" line="1009"/>
         <source>NÂº discos</source>
         <translation>Nº discos</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1011"/>
+        <location filename="../../src/funciones.cpp" line="1013"/>
         <source>TÃ­tulo</source>
         <translation>Título</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1012"/>
+        <location filename="../../src/funciones.cpp" line="1014"/>
         <source>TÃ­tulo album</source>
         <translation>Título album</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1013"/>
+        <location filename="../../src/funciones.cpp" line="1015"/>
         <source>Artista album</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1928"/>
+        <location filename="../../src/funciones.cpp" line="1930"/>
         <source>ConfiguraciÃ³n por defecto</source>
         <translation>Configuración por defecto</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1933"/>
-        <location filename="../../src/funciones.cpp" line="1934"/>
+        <location filename="../../src/funciones.cpp" line="1935"/>
+        <location filename="../../src/funciones.cpp" line="1936"/>
         <source>Importar desde un archivo</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1960"/>
+        <location filename="../../src/funciones.cpp" line="1962"/>
         <source>exterior</source>
         <translation></translation>
     </message>
@@ -959,7 +959,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3295"/>
+        <location filename="../../src/grlida.cpp" line="3317"/>
         <source>Capturas de sonidos</source>
         <translation></translation>
     </message>
@@ -1006,7 +1006,7 @@
         <location filename="../../ui/grlida.ui" line="1679"/>
         <location filename="../../ui/grlida.ui" line="1769"/>
         <location filename="../../ui/grlida.ui" line="1772"/>
-        <location filename="../../src/grlida.cpp" line="3303"/>
+        <location filename="../../src/grlida.cpp" line="3325"/>
         <source>Archivos</source>
         <translation></translation>
     </message>
@@ -1474,9 +1474,9 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1470"/>
-        <location filename="../../src/grlida.cpp" line="3835"/>
-        <location filename="../../src/grlida.cpp" line="3836"/>
-        <location filename="../../src/grlida.cpp" line="3837"/>
+        <location filename="../../src/grlida.cpp" line="3857"/>
+        <location filename="../../src/grlida.cpp" line="3858"/>
+        <location filename="../../src/grlida.cpp" line="3859"/>
         <source>PictureFlow como principal</source>
         <translation></translation>
     </message>
@@ -1658,14 +1658,14 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1969"/>
-        <location filename="../../src/grlida.cpp" line="2032"/>
+        <location filename="../../src/grlida.cpp" line="2044"/>
         <source>Icono</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1985"/>
-        <location filename="../../src/grlida.cpp" line="1607"/>
-        <location filename="../../src/grlida.cpp" line="2035"/>
+        <location filename="../../src/grlida.cpp" line="1619"/>
+        <location filename="../../src/grlida.cpp" line="2047"/>
         <source>Genero</source>
         <translation></translation>
     </message>
@@ -1676,34 +1676,34 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2001"/>
-        <location filename="../../src/grlida.cpp" line="1609"/>
-        <location filename="../../src/grlida.cpp" line="2037"/>
+        <location filename="../../src/grlida.cpp" line="1621"/>
+        <location filename="../../src/grlida.cpp" line="2049"/>
         <source>Desarrollador</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2009"/>
-        <location filename="../../src/grlida.cpp" line="1610"/>
-        <location filename="../../src/grlida.cpp" line="2038"/>
+        <location filename="../../src/grlida.cpp" line="1622"/>
+        <location filename="../../src/grlida.cpp" line="2050"/>
         <source>Tema</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2017"/>
-        <location filename="../../src/grlida.cpp" line="2039"/>
+        <location filename="../../src/grlida.cpp" line="2051"/>
         <source>Grupo</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2025"/>
-        <location filename="../../src/grlida.cpp" line="2040"/>
+        <location filename="../../src/grlida.cpp" line="2052"/>
         <source>Perspectiva</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2033"/>
-        <location filename="../../src/grlida.cpp" line="1611"/>
-        <location filename="../../src/grlida.cpp" line="2041"/>
+        <location filename="../../src/grlida.cpp" line="1623"/>
+        <location filename="../../src/grlida.cpp" line="2053"/>
         <source>Idioma</source>
         <translation></translation>
     </message>
@@ -1714,8 +1714,8 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2049"/>
-        <location filename="../../src/grlida.cpp" line="1612"/>
-        <location filename="../../src/grlida.cpp" line="2043"/>
+        <location filename="../../src/grlida.cpp" line="1624"/>
+        <location filename="../../src/grlida.cpp" line="2055"/>
         <source>Formato</source>
         <translation></translation>
     </message>
@@ -1731,7 +1731,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2073"/>
-        <location filename="../../src/grlida.cpp" line="2046"/>
+        <location filename="../../src/grlida.cpp" line="2058"/>
         <source>Sistema</source>
         <translation></translation>
     </message>
@@ -1747,28 +1747,28 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2097"/>
-        <location filename="../../src/grlida.cpp" line="1617"/>
-        <location filename="../../src/grlida.cpp" line="2049"/>
+        <location filename="../../src/grlida.cpp" line="1629"/>
+        <location filename="../../src/grlida.cpp" line="2061"/>
         <source>Sonido</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2105"/>
-        <location filename="../../src/grlida.cpp" line="1618"/>
-        <location filename="../../src/grlida.cpp" line="2050"/>
+        <location filename="../../src/grlida.cpp" line="1630"/>
+        <location filename="../../src/grlida.cpp" line="2062"/>
         <source>Jugabilidad</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2113"/>
-        <location filename="../../src/grlida.cpp" line="1619"/>
-        <location filename="../../src/grlida.cpp" line="2051"/>
+        <location filename="../../src/grlida.cpp" line="1631"/>
+        <location filename="../../src/grlida.cpp" line="2063"/>
         <source>Original</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2121"/>
-        <location filename="../../src/grlida.cpp" line="2052"/>
+        <location filename="../../src/grlida.cpp" line="2064"/>
         <source>Estado</source>
         <translation></translation>
     </message>
@@ -1784,27 +1784,27 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2151"/>
-        <location filename="../../src/grlida.cpp" line="1621"/>
-        <location filename="../../src/grlida.cpp" line="2055"/>
+        <location filename="../../src/grlida.cpp" line="1633"/>
+        <location filename="../../src/grlida.cpp" line="2067"/>
         <source>Favorito</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2162"/>
-        <location filename="../../src/grlida.cpp" line="1622"/>
-        <location filename="../../src/grlida.cpp" line="2056"/>
+        <location filename="../../src/grlida.cpp" line="1634"/>
+        <location filename="../../src/grlida.cpp" line="2068"/>
         <source>Rating</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2170"/>
-        <location filename="../../src/grlida.cpp" line="2057"/>
+        <location filename="../../src/grlida.cpp" line="2069"/>
         <source>Edad</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2178"/>
-        <location filename="../../src/grlida.cpp" line="2058"/>
+        <location filename="../../src/grlida.cpp" line="2070"/>
         <source>Usuario</source>
         <translation></translation>
     </message>
@@ -1933,357 +1933,357 @@ Esta aplicación necesita soporte de SQLite. Mira la documentación de Qt SQL dr
 Click cancelar para salir.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1537"/>
+        <location filename="../../src/grlida.cpp" line="1549"/>
         <source>InformaciÃ³n no disponible</source>
         <translation>Información no disponible</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1604"/>
+        <location filename="../../src/grlida.cpp" line="1616"/>
         <source>Por ID</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1605"/>
-        <location filename="../../src/grlida.cpp" line="2033"/>
+        <location filename="../../src/grlida.cpp" line="1617"/>
+        <location filename="../../src/grlida.cpp" line="2045"/>
         <source>TÃ­tulo</source>
         <translation>Título</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1606"/>
-        <location filename="../../src/grlida.cpp" line="2034"/>
+        <location filename="../../src/grlida.cpp" line="1618"/>
+        <location filename="../../src/grlida.cpp" line="2046"/>
         <source>SubtÃ­tulo</source>
         <translation>Subtítulo</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1608"/>
-        <location filename="../../src/grlida.cpp" line="2036"/>
+        <location filename="../../src/grlida.cpp" line="1620"/>
+        <location filename="../../src/grlida.cpp" line="2048"/>
         <source>CompaÃ±ia</source>
         <translation>Compañia</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1613"/>
-        <location filename="../../src/grlida.cpp" line="2044"/>
+        <location filename="../../src/grlida.cpp" line="1625"/>
+        <location filename="../../src/grlida.cpp" line="2056"/>
         <source>AÃ±o</source>
         <translation>Año</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1614"/>
+        <location filename="../../src/grlida.cpp" line="1626"/>
         <source>NÂº discos</source>
         <translation>Nº discos</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1615"/>
+        <location filename="../../src/grlida.cpp" line="1627"/>
         <source>Sistema OS</source>
         <translation>Sistema OS</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1616"/>
-        <location filename="../../src/grlida.cpp" line="2048"/>
+        <location filename="../../src/grlida.cpp" line="1628"/>
+        <location filename="../../src/grlida.cpp" line="2060"/>
         <source>GrÃ¡ficos</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1620"/>
-        <location filename="../../src/grlida.cpp" line="2295"/>
+        <location filename="../../src/grlida.cpp" line="1632"/>
+        <location filename="../../src/grlida.cpp" line="2307"/>
         <source>Tipo emulador</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1626"/>
+        <location filename="../../src/grlida.cpp" line="1638"/>
         <source>Ascendente</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1627"/>
+        <location filename="../../src/grlida.cpp" line="1639"/>
         <source>Descendente</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2045"/>
+        <location filename="../../src/grlida.cpp" line="2057"/>
         <source>NÂº Discos</source>
         <translation>Nº Discos</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2047"/>
+        <location filename="../../src/grlida.cpp" line="2059"/>
         <source>TamaÃ±o</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2054"/>
+        <location filename="../../src/grlida.cpp" line="2066"/>
         <source>Tipo Emu</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>de</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>NÂº juegos</source>
         <translation>Nº juegos</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2289"/>
+        <location filename="../../src/grlida.cpp" line="2301"/>
         <source>Todos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2290"/>
+        <location filename="../../src/grlida.cpp" line="2302"/>
         <source>Favoritos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2291"/>
+        <location filename="../../src/grlida.cpp" line="2303"/>
         <source>Originales</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2683"/>
+        <location filename="../../src/grlida.cpp" line="2705"/>
         <source>introducido el</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2526"/>
+        <location filename="../../src/grlida.cpp" line="2540"/>
         <source>Datos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1924"/>
+        <location filename="../../src/grlida.cpp" line="1936"/>
         <source>The file is not an XBEL version 1.0 file.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Actualizaciones</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>No existen actualizaciones.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Mostrar</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Aceptar</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2042"/>
+        <location filename="../../src/grlida.cpp" line="2054"/>
         <source>Idioma Voces</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2053"/>
+        <location filename="../../src/grlida.cpp" line="2065"/>
         <source>Fecha</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2558"/>
+        <location filename="../../src/grlida.cpp" line="2572"/>
         <source>Otro emulador</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3216"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3238"/>
         <source>Si</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3221"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3243"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3014"/>
+        <location filename="../../src/grlida.cpp" line="3036"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3171"/>
         <source>Â¿Eliminar juego...?</source>
         <translation>¿Eliminar juego...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3157"/>
+        <location filename="../../src/grlida.cpp" line="3179"/>
         <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation>¿Deseas realmente eliminar este juego de la base de datos?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3161"/>
+        <location filename="../../src/grlida.cpp" line="3183"/>
         <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
         <translation>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3162"/>
+        <location filename="../../src/grlida.cpp" line="3184"/>
         <source>Ademas borrara lo marcado siempre y cuando este dentro del directorio del GR-lida.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3177"/>
+        <location filename="../../src/grlida.cpp" line="3199"/>
         <source>Eliminar carÃ¡tula thumbs.</source>
         <translation>Eliminar carátula thumbs.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3181"/>
+        <location filename="../../src/grlida.cpp" line="3203"/>
         <source>Eliminar imÃ¡genes de la caja.</source>
         <translation>Eliminar imágenes de la caja.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3186"/>
+        <location filename="../../src/grlida.cpp" line="3208"/>
         <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3190"/>
+        <location filename="../../src/grlida.cpp" line="3212"/>
         <source>Eliminar capturas de pantalla.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3198"/>
+        <location filename="../../src/grlida.cpp" line="3220"/>
         <source>Eliminar capturas de sonido.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3202"/>
+        <location filename="../../src/grlida.cpp" line="3224"/>
         <source>Eliminar capturas de video.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3206"/>
+        <location filename="../../src/grlida.cpp" line="3228"/>
         <source>Eliminar archivos guardados.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3253"/>
+        <location filename="../../src/grlida.cpp" line="3275"/>
         <source>CarÃ¡tula</source>
         <translation>Carátula</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3260"/>
+        <location filename="../../src/grlida.cpp" line="3282"/>
         <source>ImÃ¡genes de la caja.</source>
         <translation>Imágenes de la caja.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3272"/>
+        <location filename="../../src/grlida.cpp" line="3294"/>
         <source>Capturas de pantalla</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3279"/>
+        <location filename="../../src/grlida.cpp" line="3301"/>
         <source>ImÃ¡genes del juego</source>
         <translation>Imágenes del juego</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3287"/>
+        <location filename="../../src/grlida.cpp" line="3309"/>
         <source>Capturas de videos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3313"/>
+        <location filename="../../src/grlida.cpp" line="3335"/>
         <source>ConfiguraciÃ³n de DOSBox</source>
         <translation>Configuración de DOSBox</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3331"/>
+        <location filename="../../src/grlida.cpp" line="3353"/>
         <source>ConfiguraciÃ³n de ScummVM</source>
         <translation>Configuración de ScummVM</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3339"/>
+        <location filename="../../src/grlida.cpp" line="3361"/>
         <source>ConfiguraciÃ³n de VDMSound</source>
         <translation>Configuración de VDMSound</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>El juego ha sido eliminado correctamente</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>Ha borrado</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3505"/>
+        <location filename="../../src/grlida.cpp" line="3527"/>
         <source>Ejecutar</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4816"/>
+        <location filename="../../src/grlida.cpp" line="4838"/>
         <source>Se ha producido un error al salir del proceso</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4841"/>
+        <location filename="../../src/grlida.cpp" line="4863"/>
         <source>Se ha producido un error al iniciar el proceso de inicio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4844"/>
+        <location filename="../../src/grlida.cpp" line="4866"/>
         <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
         <translation>Se ha producido un error en el proceso, tiempo después de empezar con éxito</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4847"/>
+        <location filename="../../src/grlida.cpp" line="4869"/>
         <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
         <translation>Se ha producido un error, waitFor...() Última función el tiempo de espera</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4850"/>
+        <location filename="../../src/grlida.cpp" line="4872"/>
         <source>Se ha producido un error al intentar escribir en el proceso de inicio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4853"/>
+        <location filename="../../src/grlida.cpp" line="4875"/>
         <source>Se ha producido un error al intentar leer en el proceso</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4856"/>
+        <location filename="../../src/grlida.cpp" line="4878"/>
         <source>Ha ocurrido un error desconocido</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3127"/>
-        <location filename="../../src/grlida.cpp" line="3388"/>
+        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3410"/>
         <source>Por favor selecciona un juego de la lista para eliminarlo</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3194"/>
+        <location filename="../../src/grlida.cpp" line="3216"/>
         <source>Eliminar imÃ¡genes.</source>
         <translation>Eliminar imágenes.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3807"/>
-        <location filename="../../src/grlida.cpp" line="3808"/>
-        <location filename="../../src/grlida.cpp" line="3809"/>
+        <location filename="../../src/grlida.cpp" line="3829"/>
+        <location filename="../../src/grlida.cpp" line="3830"/>
+        <location filename="../../src/grlida.cpp" line="3831"/>
         <source>Ver lista de juegos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3810"/>
+        <location filename="../../src/grlida.cpp" line="3832"/>
         <source>Lista de juegos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3813"/>
-        <location filename="../../src/grlida.cpp" line="3814"/>
-        <location filename="../../src/grlida.cpp" line="3815"/>
+        <location filename="../../src/grlida.cpp" line="3835"/>
+        <location filename="../../src/grlida.cpp" line="3836"/>
+        <location filename="../../src/grlida.cpp" line="3837"/>
         <source>Lista de juegos como principal</source>
         <translation></translation>
     </message>
@@ -2588,37 +2588,37 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="825"/>
+        <location filename="../../src/dbsql.cpp" line="859"/>
         <source>Generos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="826"/>
+        <location filename="../../src/dbsql.cpp" line="860"/>
         <source>Temas</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="827"/>
+        <location filename="../../src/dbsql.cpp" line="861"/>
         <source>Desarrolladores</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="828"/>
+        <location filename="../../src/dbsql.cpp" line="862"/>
         <source>CompaÃ±ias</source>
         <translation>Compañias</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="829"/>
+        <location filename="../../src/dbsql.cpp" line="863"/>
         <source>AÃ±os</source>
         <translation>Años</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="830"/>
+        <location filename="../../src/dbsql.cpp" line="864"/>
         <source>Idiomas</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="849"/>
+        <location filename="../../src/dbsql.cpp" line="883"/>
         <source>Todos</source>
         <translation></translation>
     </message>
@@ -3502,11 +3502,11 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Selecciona un archivo</source>
         <translation></translation>
     </message>
@@ -3519,11 +3519,11 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Todos los archivos</source>
         <translation></translation>
     </message>
@@ -3548,29 +3548,29 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
         <translation>¿Deseas eliminar este montaje?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1215"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1222"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1229"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1209"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1216"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1223"/>
         <source>Seleccionar un directorio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
         <source>Imagen</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
         <source>Imagen CD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
         <source>Imagen HD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Idioma</source>
         <translation></translation>
     </message>
@@ -4405,121 +4405,130 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="64"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
         <source>Imagen ISO multiples</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
         <source>Imagen de disco duro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="68"/>
         <source>Imagen Botable</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="70"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <source>No usar nada</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Usar</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
         <translation>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
         <translation>Selección automática de la interfaz de audio de CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
         <translation>Extracción digital de audio utilizado para los CD de audio</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
         <translation>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Todos los archivos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <source>Llamadas ioctl utiliza para CD de audio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
         <source>MCI utiliza para CD de audio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="87"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="88"/>
         <source>NO usar CD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>Procura no montar la Raiz del sistema operativo: ejemplo en windows seria</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>y en linux seria directamente</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="272"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="273"/>
         <source>Seleccionar un directorio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="281"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="282"/>
         <source>Imagen</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="283"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="284"/>
         <source>Imagen CD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Selecciona un archivo</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
         <source>Â¿Eliminar...?</source>
         <translation>¿Eliminar...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
         <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>¿Quieres eliminar la ISO de la lista?</translation>
+        <translation type="obsolete">¿Quieres eliminar la ISO de la lista?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="397"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="398"/>
         <source>Espacio libre virtual (%1 %2)</source>
         <translation></translation>
     </message>
@@ -6707,68 +6716,77 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="86"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
         <source>Imagen ISO multiples</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="89"/>
         <source>Imagen de disco duro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="131"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="132"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="168"/>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="252"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="169"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="253"/>
         <source>Seleccionar un directorio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="177"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="178"/>
         <source>Imagen</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="179"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="180"/>
         <source>Imagen CD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Selecciona un archivo</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Todos los archivos</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
         <source>Â¿Eliminar...?</source>
         <translation>¿Eliminar...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>¿Quieres eliminar la ISO de la lista?</translation>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="282"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">¿Quieres eliminar la ISO de la lista?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="283"/>
         <source>El ejecutable suele ser: INSTALL, si no esta seguro teclee DIR y pulsa INTRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="347"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="355"/>
         <source>Puede que no este disponible el ejecutable del emulador.
 O el directorio de destino.</source>
         <translation></translation>
@@ -8329,6 +8347,51 @@ O el directorio de destino.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="174"/>
+        <source>Cada veinticuatro horas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="175"/>
+        <source>Semanalmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="176"/>
+        <source>Mensualmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="202"/>
+        <location filename="../../src/grlida_opciones.cpp" line="246"/>
+        <location filename="../../src/grlida_opciones.cpp" line="283"/>
+        <location filename="../../src/grlida_opciones.cpp" line="316"/>
+        <location filename="../../src/grlida_opciones.cpp" line="342"/>
+        <location filename="../../src/grlida_opciones.cpp" line="391"/>
+        <location filename="../../src/grlida_opciones.cpp" line="498"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2427"/>
+        <source>ImÃ¡genes CategorÃ­as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="249"/>
+        <location filename="../../src/grlida_opciones.cpp" line="286"/>
+        <location filename="../../src/grlida_opciones.cpp" line="319"/>
+        <location filename="../../src/grlida_opciones.cpp" line="345"/>
+        <location filename="../../src/grlida_opciones.cpp" line="394"/>
+        <location filename="../../src/grlida_opciones.cpp" line="501"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2429"/>
+        <source>ImÃ¡genes defecto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="322"/>
+        <location filename="../../src/grlida_opciones.cpp" line="348"/>
+        <location filename="../../src/grlida_opciones.cpp" line="504"/>
+        <source>ImÃ¡genes idiomas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/grlida_opciones.cpp" line="555"/>
         <source>Thumb en JPG</source>
         <translation></translation>
@@ -8715,6 +8778,13 @@ O el directorio de destino.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="3075"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3105"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3135"/>
+        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/grlida_opciones.cpp" line="1542"/>
         <source>Selecciona el ejecutable</source>
         <translation></translation>
@@ -8771,6 +8841,7 @@ O el directorio de destino.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="2440"/>
         <location filename="../../src/grlida_opciones.cpp" line="2490"/>
         <location filename="../../src/grlida_opciones.cpp" line="2508"/>
         <source>Config</source>
@@ -8907,7 +8978,7 @@ O el directorio de destino.</source>
     <message>
         <location filename="../../ui/update.ui" line="20"/>
         <location filename="../../ui/update.ui" line="64"/>
-        <location filename="../../src/grlida_update.cpp" line="108"/>
+        <location filename="../../src/grlida_update.cpp" line="121"/>
         <source>Actualizaciones</source>
         <translation></translation>
     </message>
@@ -8932,27 +9003,27 @@ O el directorio de destino.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="64"/>
+        <location filename="../../src/grlida_update.cpp" line="74"/>
         <source>Estilos o themes para el GR-lida</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Descargar</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Actualizar</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="70"/>
+        <location filename="../../src/grlida_update.cpp" line="82"/>
         <source>Lista de compatibilidad del ScummVM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="58"/>
+        <location filename="../../src/grlida_update.cpp" line="65"/>
         <source>Script para importar datos del juego</source>
         <translation></translation>
     </message>

--- a/res/idiomas/gr-lida_fr_FR.ts
+++ b/res/idiomas/gr-lida_fr_FR.ts
@@ -241,188 +241,188 @@
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="978"/>
+        <location filename="../../src/funciones.cpp" line="980"/>
         <source>CarÃ¡tula frontal</source>
         <translation>Couverture (devant)</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="979"/>
+        <location filename="../../src/funciones.cpp" line="981"/>
         <source>Detalles del juego</source>
         <translation>Détails du jeu</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="980"/>
+        <location filename="../../src/funciones.cpp" line="982"/>
         <source>CalificaciÃ³n</source>
         <translation>Note</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="981"/>
+        <location filename="../../src/funciones.cpp" line="983"/>
         <source>Otros datos</source>
         <translation>Autres données</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="982"/>
+        <location filename="../../src/funciones.cpp" line="984"/>
         <source>Subido por</source>
         <translation>Soumis par</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="983"/>
+        <location filename="../../src/funciones.cpp" line="985"/>
         <source>SubtÃ­tulo</source>
         <translation>Soustitre</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="984"/>
+        <location filename="../../src/funciones.cpp" line="986"/>
         <source>Publicado por</source>
         <translation>Publié par</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="985"/>
+        <location filename="../../src/funciones.cpp" line="987"/>
         <source>Desarrollado por</source>
         <translation>Développeur par</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="986"/>
+        <location filename="../../src/funciones.cpp" line="988"/>
         <source>Publicado</source>
         <translation>Publié</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="987"/>
+        <location filename="../../src/funciones.cpp" line="989"/>
         <source>Edad recomendada</source>
         <translation>Age recommandé</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="988"/>
+        <location filename="../../src/funciones.cpp" line="990"/>
         <source>Idioma</source>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="989"/>
+        <location filename="../../src/funciones.cpp" line="991"/>
         <source>Idioma voces</source>
         <translation>Voix langue</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="990"/>
+        <location filename="../../src/funciones.cpp" line="992"/>
         <source>Formato</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="991"/>
+        <location filename="../../src/funciones.cpp" line="993"/>
         <source>Genero</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="992"/>
+        <location filename="../../src/funciones.cpp" line="994"/>
         <source>Tema</source>
         <translation>Theme</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="993"/>
+        <location filename="../../src/funciones.cpp" line="995"/>
         <source>Grupo</source>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="994"/>
+        <location filename="../../src/funciones.cpp" line="996"/>
         <source>Perspectiva</source>
         <translation>Perspective</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="995"/>
+        <location filename="../../src/funciones.cpp" line="997"/>
         <source>Sistema operativo</source>
         <translation>Système d&apos;exploitation</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="996"/>
+        <location filename="../../src/funciones.cpp" line="998"/>
         <source>Favorito</source>
         <translation>Favori</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>Joystick</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>GamePad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="998"/>
+        <location filename="../../src/funciones.cpp" line="1000"/>
         <source>AÃ±adido el</source>
         <translation>Ajouté le</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="999"/>
+        <location filename="../../src/funciones.cpp" line="1001"/>
         <source>GrÃ¡ficos</source>
         <translation>Graphismes</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1000"/>
+        <location filename="../../src/funciones.cpp" line="1002"/>
         <source>Sonido</source>
         <translation>Son</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1001"/>
+        <location filename="../../src/funciones.cpp" line="1003"/>
         <source>Jugabilidad</source>
         <translation>Jouabilité</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1002"/>
+        <location filename="../../src/funciones.cpp" line="1004"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1003"/>
+        <location filename="../../src/funciones.cpp" line="1005"/>
         <source>Estado</source>
         <translation>Etat</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1004"/>
+        <location filename="../../src/funciones.cpp" line="1006"/>
         <source>Tipo Emu</source>
         <translation>Type émulation</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1005"/>
+        <location filename="../../src/funciones.cpp" line="1007"/>
         <source>DescripciÃ³n</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1006"/>
+        <location filename="../../src/funciones.cpp" line="1008"/>
         <source>Rating</source>
         <translation>Classement</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1007"/>
+        <location filename="../../src/funciones.cpp" line="1009"/>
         <source>NÂº discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1011"/>
+        <location filename="../../src/funciones.cpp" line="1013"/>
         <source>TÃ­tulo</source>
         <translation>Titre</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1012"/>
+        <location filename="../../src/funciones.cpp" line="1014"/>
         <source>TÃ­tulo album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1013"/>
+        <location filename="../../src/funciones.cpp" line="1015"/>
         <source>Artista album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1928"/>
+        <location filename="../../src/funciones.cpp" line="1930"/>
         <source>ConfiguraciÃ³n por defecto</source>
         <translation>Configuration par défault</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1933"/>
-        <location filename="../../src/funciones.cpp" line="1934"/>
+        <location filename="../../src/funciones.cpp" line="1935"/>
+        <location filename="../../src/funciones.cpp" line="1936"/>
         <source>Importar desde un archivo</source>
         <translation>Importer depuis une archive</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1960"/>
+        <location filename="../../src/funciones.cpp" line="1962"/>
         <source>exterior</source>
         <translation>extérieur</translation>
     </message>
@@ -876,14 +876,14 @@
 <context>
     <name>GrLida</name>
     <message>
-        <location filename="../../src/grlida.cpp" line="1604"/>
+        <location filename="../../src/grlida.cpp" line="1616"/>
         <source>Por ID</source>
         <translation>Par ID</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1985"/>
-        <location filename="../../src/grlida.cpp" line="1607"/>
-        <location filename="../../src/grlida.cpp" line="2035"/>
+        <location filename="../../src/grlida.cpp" line="1619"/>
+        <location filename="../../src/grlida.cpp" line="2047"/>
         <source>Genero</source>
         <translation>Genre</translation>
     </message>
@@ -1408,9 +1408,9 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1470"/>
-        <location filename="../../src/grlida.cpp" line="3835"/>
-        <location filename="../../src/grlida.cpp" line="3836"/>
-        <location filename="../../src/grlida.cpp" line="3837"/>
+        <location filename="../../src/grlida.cpp" line="3857"/>
+        <location filename="../../src/grlida.cpp" line="3858"/>
+        <location filename="../../src/grlida.cpp" line="3859"/>
         <source>PictureFlow como principal</source>
         <translation>PictureFlow en vue principale</translation>
     </message>
@@ -1430,7 +1430,7 @@
         <location filename="../../ui/grlida.ui" line="1679"/>
         <location filename="../../ui/grlida.ui" line="1769"/>
         <location filename="../../ui/grlida.ui" line="1772"/>
-        <location filename="../../src/grlida.cpp" line="3303"/>
+        <location filename="../../src/grlida.cpp" line="3325"/>
         <source>Archivos</source>
         <translation>Fichier</translation>
     </message>
@@ -1602,7 +1602,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1969"/>
-        <location filename="../../src/grlida.cpp" line="2032"/>
+        <location filename="../../src/grlida.cpp" line="2044"/>
         <source>Icono</source>
         <translation>Icone</translation>
     </message>
@@ -1618,35 +1618,35 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2001"/>
-        <location filename="../../src/grlida.cpp" line="1609"/>
-        <location filename="../../src/grlida.cpp" line="2037"/>
+        <location filename="../../src/grlida.cpp" line="1621"/>
+        <location filename="../../src/grlida.cpp" line="2049"/>
         <source>Desarrollador</source>
         <translation>Développeur</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2009"/>
-        <location filename="../../src/grlida.cpp" line="1610"/>
-        <location filename="../../src/grlida.cpp" line="2038"/>
+        <location filename="../../src/grlida.cpp" line="1622"/>
+        <location filename="../../src/grlida.cpp" line="2050"/>
         <source>Tema</source>
         <translation>Theme</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2017"/>
-        <location filename="../../src/grlida.cpp" line="2039"/>
+        <location filename="../../src/grlida.cpp" line="2051"/>
         <source>Grupo</source>
         <translation>Groupe</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2033"/>
-        <location filename="../../src/grlida.cpp" line="1611"/>
-        <location filename="../../src/grlida.cpp" line="2041"/>
+        <location filename="../../src/grlida.cpp" line="1623"/>
+        <location filename="../../src/grlida.cpp" line="2053"/>
         <source>Idioma</source>
         <translation>Langue</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2049"/>
-        <location filename="../../src/grlida.cpp" line="1612"/>
-        <location filename="../../src/grlida.cpp" line="2043"/>
+        <location filename="../../src/grlida.cpp" line="1624"/>
+        <location filename="../../src/grlida.cpp" line="2055"/>
         <source>Formato</source>
         <translation>Format</translation>
     </message>
@@ -1657,7 +1657,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2073"/>
-        <location filename="../../src/grlida.cpp" line="2046"/>
+        <location filename="../../src/grlida.cpp" line="2058"/>
         <source>Sistema</source>
         <translation>OS</translation>
     </message>
@@ -1683,13 +1683,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2170"/>
-        <location filename="../../src/grlida.cpp" line="2057"/>
+        <location filename="../../src/grlida.cpp" line="2069"/>
         <source>Edad</source>
         <translation>Age</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2178"/>
-        <location filename="../../src/grlida.cpp" line="2058"/>
+        <location filename="../../src/grlida.cpp" line="2070"/>
         <source>Usuario</source>
         <translation>Utilisateur</translation>
     </message>
@@ -1803,7 +1803,7 @@
         <translation>Fichiers / couvertures disponibles</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3295"/>
+        <location filename="../../src/grlida.cpp" line="3317"/>
         <source>Capturas de sonidos</source>
         <translation>Captures audio</translation>
     </message>
@@ -1860,48 +1860,48 @@
         <translation>&amp;Restaurer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1615"/>
+        <location filename="../../src/grlida.cpp" line="1627"/>
         <source>Sistema OS</source>
         <translation>OS</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2097"/>
-        <location filename="../../src/grlida.cpp" line="1617"/>
-        <location filename="../../src/grlida.cpp" line="2049"/>
+        <location filename="../../src/grlida.cpp" line="1629"/>
+        <location filename="../../src/grlida.cpp" line="2061"/>
         <source>Sonido</source>
         <translation>Son</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2105"/>
-        <location filename="../../src/grlida.cpp" line="1618"/>
-        <location filename="../../src/grlida.cpp" line="2050"/>
+        <location filename="../../src/grlida.cpp" line="1630"/>
+        <location filename="../../src/grlida.cpp" line="2062"/>
         <source>Jugabilidad</source>
         <translation>Jouabilité</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2113"/>
-        <location filename="../../src/grlida.cpp" line="1619"/>
-        <location filename="../../src/grlida.cpp" line="2051"/>
+        <location filename="../../src/grlida.cpp" line="1631"/>
+        <location filename="../../src/grlida.cpp" line="2063"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1620"/>
-        <location filename="../../src/grlida.cpp" line="2295"/>
+        <location filename="../../src/grlida.cpp" line="1632"/>
+        <location filename="../../src/grlida.cpp" line="2307"/>
         <source>Tipo emulador</source>
         <translation>Type émulation</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2151"/>
-        <location filename="../../src/grlida.cpp" line="1621"/>
-        <location filename="../../src/grlida.cpp" line="2055"/>
+        <location filename="../../src/grlida.cpp" line="1633"/>
+        <location filename="../../src/grlida.cpp" line="2067"/>
         <source>Favorito</source>
         <translation>Favori</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2162"/>
-        <location filename="../../src/grlida.cpp" line="1622"/>
-        <location filename="../../src/grlida.cpp" line="2056"/>
+        <location filename="../../src/grlida.cpp" line="1634"/>
+        <location filename="../../src/grlida.cpp" line="2068"/>
         <source>Rating</source>
         <translation>Classement</translation>
     </message>
@@ -1911,12 +1911,12 @@
         <translation>par</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1626"/>
+        <location filename="../../src/grlida.cpp" line="1638"/>
         <source>Ascendente</source>
         <translation>Croissant</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1627"/>
+        <location filename="../../src/grlida.cpp" line="1639"/>
         <source>Descendente</source>
         <translation>Décroissant</translation>
     </message>
@@ -1926,17 +1926,17 @@
         <translation>Trier</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2289"/>
+        <location filename="../../src/grlida.cpp" line="2301"/>
         <source>Todos</source>
         <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2290"/>
+        <location filename="../../src/grlida.cpp" line="2302"/>
         <source>Favoritos</source>
         <translation>favoris</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2291"/>
+        <location filename="../../src/grlida.cpp" line="2303"/>
         <source>Originales</source>
         <translation>Originaux</translation>
     </message>
@@ -1946,31 +1946,31 @@
         <translation>Erreur d&apos;ouverture de la base de données</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2526"/>
+        <location filename="../../src/grlida.cpp" line="2540"/>
         <source>Datos</source>
         <translation>Données</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2558"/>
+        <location filename="../../src/grlida.cpp" line="2572"/>
         <source>Otro emulador</source>
         <translation>Autre émulateur</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3807"/>
-        <location filename="../../src/grlida.cpp" line="3808"/>
-        <location filename="../../src/grlida.cpp" line="3809"/>
+        <location filename="../../src/grlida.cpp" line="3829"/>
+        <location filename="../../src/grlida.cpp" line="3830"/>
+        <location filename="../../src/grlida.cpp" line="3831"/>
         <source>Ver lista de juegos</source>
         <translation>Afficher la liste de jeux</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3810"/>
+        <location filename="../../src/grlida.cpp" line="3832"/>
         <source>Lista de juegos</source>
         <translation>Liste de jeux</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3813"/>
-        <location filename="../../src/grlida.cpp" line="3814"/>
-        <location filename="../../src/grlida.cpp" line="3815"/>
+        <location filename="../../src/grlida.cpp" line="3835"/>
+        <location filename="../../src/grlida.cpp" line="3836"/>
+        <location filename="../../src/grlida.cpp" line="3837"/>
         <source>Lista de juegos como principal</source>
         <translation>Liste des jeux en vue principale</translation>
     </message>
@@ -1981,13 +1981,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2025"/>
-        <location filename="../../src/grlida.cpp" line="2040"/>
+        <location filename="../../src/grlida.cpp" line="2052"/>
         <source>Perspectiva</source>
         <translation>Perspective</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2121"/>
-        <location filename="../../src/grlida.cpp" line="2052"/>
+        <location filename="../../src/grlida.cpp" line="2064"/>
         <source>Estado</source>
         <translation>Etat</translation>
     </message>
@@ -2003,286 +2003,286 @@ Le programme nécessite le support SQlite. Voir la documentation de Qt SQL drive
 Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1605"/>
-        <location filename="../../src/grlida.cpp" line="2033"/>
+        <location filename="../../src/grlida.cpp" line="1617"/>
+        <location filename="../../src/grlida.cpp" line="2045"/>
         <source>TÃ­tulo</source>
         <translation>Titre</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1608"/>
-        <location filename="../../src/grlida.cpp" line="2036"/>
+        <location filename="../../src/grlida.cpp" line="1620"/>
+        <location filename="../../src/grlida.cpp" line="2048"/>
         <source>CompaÃ±ia</source>
         <translation>Editeur</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1613"/>
-        <location filename="../../src/grlida.cpp" line="2044"/>
+        <location filename="../../src/grlida.cpp" line="1625"/>
+        <location filename="../../src/grlida.cpp" line="2056"/>
         <source>AÃ±o</source>
         <translation>Année</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1614"/>
+        <location filename="../../src/grlida.cpp" line="1626"/>
         <source>NÂº discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1616"/>
-        <location filename="../../src/grlida.cpp" line="2048"/>
+        <location filename="../../src/grlida.cpp" line="1628"/>
+        <location filename="../../src/grlida.cpp" line="2060"/>
         <source>GrÃ¡ficos</source>
         <translation>Graphismes</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2054"/>
+        <location filename="../../src/grlida.cpp" line="2066"/>
         <source>Tipo Emu</source>
         <translation>Type émulation</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2047"/>
+        <location filename="../../src/grlida.cpp" line="2059"/>
         <source>TamaÃ±o</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>de</source>
         <translation>de</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>NÂº juegos</source>
         <translation>Nº jeux</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1537"/>
+        <location filename="../../src/grlida.cpp" line="1549"/>
         <source>InformaciÃ³n no disponible</source>
         <translation>Information non disponible</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2683"/>
+        <location filename="../../src/grlida.cpp" line="2705"/>
         <source>introducido el</source>
         <translation>Entré le</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3216"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3238"/>
         <source>Si</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1606"/>
-        <location filename="../../src/grlida.cpp" line="2034"/>
+        <location filename="../../src/grlida.cpp" line="1618"/>
+        <location filename="../../src/grlida.cpp" line="2046"/>
         <source>SubtÃ­tulo</source>
         <translation>Soustitre</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1924"/>
+        <location filename="../../src/grlida.cpp" line="1936"/>
         <source>The file is not an XBEL version 1.0 file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Actualizaciones</source>
         <translation>Mises à jour</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>No existen actualizaciones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Mostrar</source>
         <translation>Montrer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Aceptar</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2042"/>
+        <location filename="../../src/grlida.cpp" line="2054"/>
         <source>Idioma Voces</source>
         <translation>Voix langue</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2045"/>
+        <location filename="../../src/grlida.cpp" line="2057"/>
         <source>NÂº Discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2053"/>
+        <location filename="../../src/grlida.cpp" line="2065"/>
         <source>Fecha</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3221"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3243"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3157"/>
+        <location filename="../../src/grlida.cpp" line="3179"/>
         <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3161"/>
+        <location filename="../../src/grlida.cpp" line="3183"/>
         <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3162"/>
+        <location filename="../../src/grlida.cpp" line="3184"/>
         <source>Ademas borrara lo marcado siempre y cuando este dentro del directorio del GR-lida.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3177"/>
+        <location filename="../../src/grlida.cpp" line="3199"/>
         <source>Eliminar carÃ¡tula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3181"/>
+        <location filename="../../src/grlida.cpp" line="3203"/>
         <source>Eliminar imÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3186"/>
+        <location filename="../../src/grlida.cpp" line="3208"/>
         <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3190"/>
+        <location filename="../../src/grlida.cpp" line="3212"/>
         <source>Eliminar capturas de pantalla.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3194"/>
+        <location filename="../../src/grlida.cpp" line="3216"/>
         <source>Eliminar imÃ¡genes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3198"/>
+        <location filename="../../src/grlida.cpp" line="3220"/>
         <source>Eliminar capturas de sonido.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3202"/>
+        <location filename="../../src/grlida.cpp" line="3224"/>
         <source>Eliminar capturas de video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3206"/>
+        <location filename="../../src/grlida.cpp" line="3228"/>
         <source>Eliminar archivos guardados.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3253"/>
+        <location filename="../../src/grlida.cpp" line="3275"/>
         <source>CarÃ¡tula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3260"/>
+        <location filename="../../src/grlida.cpp" line="3282"/>
         <source>ImÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3272"/>
+        <location filename="../../src/grlida.cpp" line="3294"/>
         <source>Capturas de pantalla</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3279"/>
+        <location filename="../../src/grlida.cpp" line="3301"/>
         <source>ImÃ¡genes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3287"/>
+        <location filename="../../src/grlida.cpp" line="3309"/>
         <source>Capturas de videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3313"/>
+        <location filename="../../src/grlida.cpp" line="3335"/>
         <source>ConfiguraciÃ³n de DOSBox</source>
         <translation>Configurer DOSBox</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3331"/>
+        <location filename="../../src/grlida.cpp" line="3353"/>
         <source>ConfiguraciÃ³n de ScummVM</source>
         <translation>Configuration de ScummVm</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3339"/>
+        <location filename="../../src/grlida.cpp" line="3361"/>
         <source>ConfiguraciÃ³n de VDMSound</source>
         <translation>Configurer VDMSound</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>El juego ha sido eliminado correctamente</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>Ha borrado</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3505"/>
+        <location filename="../../src/grlida.cpp" line="3527"/>
         <source>Ejecutar</source>
         <translation>Lancer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4816"/>
+        <location filename="../../src/grlida.cpp" line="4838"/>
         <source>Se ha producido un error al salir del proceso</source>
         <translation>Erreur de sortie du processus</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4841"/>
+        <location filename="../../src/grlida.cpp" line="4863"/>
         <source>Se ha producido un error al iniciar el proceso de inicio</source>
         <translation>Erreur au lancement du processus de démarrage</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4844"/>
+        <location filename="../../src/grlida.cpp" line="4866"/>
         <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
         <translation>Erreur dans le processus, temps après le démarrage réussi</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4847"/>
+        <location filename="../../src/grlida.cpp" line="4869"/>
         <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
         <translation>Une erreur s&apos;est produite, waitFor...() dernière fonction du temps d&apos;attente</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4850"/>
+        <location filename="../../src/grlida.cpp" line="4872"/>
         <source>Se ha producido un error al intentar escribir en el proceso de inicio</source>
         <translation>Erreur d&apos;écriture lors du processus de démarrage</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4853"/>
+        <location filename="../../src/grlida.cpp" line="4875"/>
         <source>Se ha producido un error al intentar leer en el proceso</source>
         <translation>Erreur de lecture du processus</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4856"/>
+        <location filename="../../src/grlida.cpp" line="4878"/>
         <source>Ha ocurrido un error desconocido</source>
         <translation>Une erreur inconnue s&apos;est produite</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3127"/>
-        <location filename="../../src/grlida.cpp" line="3388"/>
+        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3410"/>
         <source>Por favor selecciona un juego de la lista para eliminarlo</source>
         <translation>Choisir un jeu de la liste à effacer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3171"/>
         <source>Â¿Eliminar juego...?</source>
         <translation>Effacer le jeu?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3014"/>
+        <location filename="../../src/grlida.cpp" line="3036"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>L&apos;exécutable de l&apos;émulateur n&apos;est pas disponible.
@@ -2588,37 +2588,37 @@ Please check the media service plugins are installed.</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="825"/>
+        <location filename="../../src/dbsql.cpp" line="859"/>
         <source>Generos</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="826"/>
+        <location filename="../../src/dbsql.cpp" line="860"/>
         <source>Temas</source>
         <translation>Thème</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="827"/>
+        <location filename="../../src/dbsql.cpp" line="861"/>
         <source>Desarrolladores</source>
         <translation>Développeur</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="828"/>
+        <location filename="../../src/dbsql.cpp" line="862"/>
         <source>CompaÃ±ias</source>
         <translation>Editeur</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="829"/>
+        <location filename="../../src/dbsql.cpp" line="863"/>
         <source>AÃ±os</source>
         <translation>Année</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="830"/>
+        <location filename="../../src/dbsql.cpp" line="864"/>
         <source>Idiomas</source>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="849"/>
+        <location filename="../../src/dbsql.cpp" line="883"/>
         <source>Todos</source>
         <translation>Tout</translation>
     </message>
@@ -2748,11 +2748,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Selecciona un archivo</source>
         <translation>Choisir un fichier</translation>
     </message>
@@ -2765,11 +2765,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Todos los archivos</source>
         <translation>Tous les fichiers</translation>
     </message>
@@ -2794,19 +2794,19 @@ Please check the media service plugins are installed.</source>
         <translation>Vraiment effacer ce point de montage?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1215"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1222"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1229"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1209"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1216"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1223"/>
         <source>Seleccionar un directorio</source>
         <translation>Choisi un répertoire</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Idioma</source>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
         <source>Imagen</source>
         <translation>Image</translation>
     </message>
@@ -2816,12 +2816,12 @@ Please check the media service plugins are installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
         <source>Imagen CD</source>
         <translation>Image CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
         <source>Imagen HD</source>
         <translation>Image HD</translation>
     </message>
@@ -4358,121 +4358,130 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="64"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>Image ISO, CUE/BIN</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
         <source>Imagen ISO multiples</source>
         <translation>Image ISO multiple</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
         <source>Imagen de disco duro</source>
         <translation>Image de disque dur</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="68"/>
         <source>Imagen Botable</source>
         <translation>Image bootable</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="70"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <source>No usar nada</source>
         <translation>Ne rien utiliser</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Usar</source>
         <translation>Utiliser</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
         <translation>Forcer l&apos;utilisation de la couche ASPI. Fonctionne seulement sur Windows avec ASPI installé</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
         <translation>Sélection automatique de l&apos;interface CD audio</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
         <translation>Extraction audio digitale pour les CD audio</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <source>Llamadas ioctl utiliza para CD de audio</source>
         <translation>Appel IOCTL pour CD audio</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
         <source>MCI utiliza para CD de audio</source>
         <translation>Utiliser MCI pour les CD audio</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
         <translation>Forcer l&apos;utilisation de SDL pour le CD-ROM. Disponible pour tous les sytèmes</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="87"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="88"/>
         <source>NO usar CD</source>
         <translation>Ne pas utiliser le CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="272"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="273"/>
         <source>Seleccionar un directorio</source>
         <translation>Choisi un répertoire</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Todos los archivos</source>
         <translation>Tous les fichiers</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
         <source>Â¿Eliminar...?</source>
         <translation>Effacer...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Vraiment effacer l&apos;ISO de la liste?</translation>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="397"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Vraiment effacer l&apos;ISO de la liste?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="398"/>
         <source>Espacio libre virtual (%1 %2)</source>
         <translation>Espace libre virtuel (%1 %2)</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>Procura no montar la Raiz del sistema operativo: ejemplo en windows seria</source>
         <translation>Permet de ne pas monter la Racine du syst. d&apos;expl. : par exemple sous windows</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>y en linux seria directamente</source>
         <translation>et sous linux ce serait directement</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="281"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="282"/>
         <source>Imagen</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="283"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="284"/>
         <source>Imagen CD</source>
         <translation>Image CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Selecciona un archivo</source>
         <translation>Choisir un fichier</translation>
     </message>
@@ -6670,69 +6679,78 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="86"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>Image ISO, CUE/BIN</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
         <source>Imagen ISO multiples</source>
         <translation>Image ISO multiple</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="89"/>
         <source>Imagen de disco duro</source>
         <translation>Image de disque dur</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="168"/>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="252"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="169"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="253"/>
         <source>Seleccionar un directorio</source>
         <translation>Choisi un répertoire</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Todos los archivos</source>
         <translation>Tous les fichiers</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
         <source>Â¿Eliminar...?</source>
         <translation>Effacer...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Vraiment effacer l&apos;ISO de la liste?</translation>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="282"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Vraiment effacer l&apos;ISO de la liste?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="283"/>
         <source>El ejecutable suele ser: INSTALL, si no esta seguro teclee DIR y pulsa INTRO</source>
         <translation>L&apos;exécutable est habituellement nommé INSTALL. En cas de doute taper DIR et presser ENTRÉE</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="347"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="355"/>
         <source>Puede que no este disponible el ejecutable del emulador.
 O el directorio de destino.</source>
         <translation>Il est possible que l&apos;émulateur ne soit pas disponible, 
 ou que le dossier de destination soit invalide.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="177"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="178"/>
         <source>Imagen</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="179"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="180"/>
         <source>Imagen CD</source>
         <translation>Image CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Selecciona un archivo</source>
         <translation>Choisir un fichier</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="131"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="132"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>L&apos;exécutable de l&apos;émulateur n&apos;est pas disponible.
@@ -7483,6 +7501,7 @@ Vérifier l&apos;installation.</translation>
         <translation>Label</translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="2440"/>
         <location filename="../../src/grlida_opciones.cpp" line="2490"/>
         <location filename="../../src/grlida_opciones.cpp" line="2508"/>
         <source>Config</source>
@@ -7800,6 +7819,51 @@ Vérifier l&apos;installation.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="174"/>
+        <source>Cada veinticuatro horas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="175"/>
+        <source>Semanalmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="176"/>
+        <source>Mensualmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="202"/>
+        <location filename="../../src/grlida_opciones.cpp" line="246"/>
+        <location filename="../../src/grlida_opciones.cpp" line="283"/>
+        <location filename="../../src/grlida_opciones.cpp" line="316"/>
+        <location filename="../../src/grlida_opciones.cpp" line="342"/>
+        <location filename="../../src/grlida_opciones.cpp" line="391"/>
+        <location filename="../../src/grlida_opciones.cpp" line="498"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2427"/>
+        <source>ImÃ¡genes CategorÃ­as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="249"/>
+        <location filename="../../src/grlida_opciones.cpp" line="286"/>
+        <location filename="../../src/grlida_opciones.cpp" line="319"/>
+        <location filename="../../src/grlida_opciones.cpp" line="345"/>
+        <location filename="../../src/grlida_opciones.cpp" line="394"/>
+        <location filename="../../src/grlida_opciones.cpp" line="501"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2429"/>
+        <source>ImÃ¡genes defecto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="322"/>
+        <location filename="../../src/grlida_opciones.cpp" line="348"/>
+        <location filename="../../src/grlida_opciones.cpp" line="504"/>
+        <source>ImÃ¡genes idiomas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/grlida_opciones.cpp" line="555"/>
         <source>Thumb en JPG</source>
         <translation type="unfinished"></translation>
@@ -7957,6 +8021,13 @@ Vérifier l&apos;installation.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2836"/>
         <source>Color de texto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="3075"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3105"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3135"/>
+        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8917,7 +8988,7 @@ Vérifier l&apos;installation.</translation>
     <message>
         <location filename="../../ui/update.ui" line="20"/>
         <location filename="../../ui/update.ui" line="64"/>
-        <location filename="../../src/grlida_update.cpp" line="108"/>
+        <location filename="../../src/grlida_update.cpp" line="121"/>
         <source>Actualizaciones</source>
         <translation>Mises à jour</translation>
     </message>
@@ -8942,27 +9013,27 @@ Vérifier l&apos;installation.</translation>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="64"/>
+        <location filename="../../src/grlida_update.cpp" line="74"/>
         <source>Estilos o themes para el GR-lida</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Descargar</source>
         <translation>Télécharger</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Actualizar</source>
         <translation>Rafraichir</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="70"/>
+        <location filename="../../src/grlida_update.cpp" line="82"/>
         <source>Lista de compatibilidad del ScummVM</source>
         <translation>Liste de compatibilité ScummVM</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="58"/>
+        <location filename="../../src/grlida_update.cpp" line="65"/>
         <source>Script para importar datos del juego</source>
         <translation>Script d&apos;importation de données du jeu</translation>
     </message>

--- a/res/idiomas/gr-lida_hu_HU.ts
+++ b/res/idiomas/gr-lida_hu_HU.ts
@@ -241,188 +241,188 @@
         <translation>Nem</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="978"/>
+        <location filename="../../src/funciones.cpp" line="980"/>
         <source>CarÃ¡tula frontal</source>
         <translation>Előlap</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="979"/>
+        <location filename="../../src/funciones.cpp" line="981"/>
         <source>Detalles del juego</source>
         <translation>Játék részletek</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="980"/>
+        <location filename="../../src/funciones.cpp" line="982"/>
         <source>CalificaciÃ³n</source>
         <translation>Értékelés</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="981"/>
+        <location filename="../../src/funciones.cpp" line="983"/>
         <source>Otros datos</source>
         <translation>Más Adatok</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="982"/>
+        <location filename="../../src/funciones.cpp" line="984"/>
         <source>Subido por</source>
         <translation>Feltöltötte</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="983"/>
+        <location filename="../../src/funciones.cpp" line="985"/>
         <source>SubtÃ­tulo</source>
         <translation>Alcím</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="984"/>
+        <location filename="../../src/funciones.cpp" line="986"/>
         <source>Publicado por</source>
         <translation>Kiadta</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="985"/>
+        <location filename="../../src/funciones.cpp" line="987"/>
         <source>Desarrollado por</source>
         <translation>Fejlesztette</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="986"/>
+        <location filename="../../src/funciones.cpp" line="988"/>
         <source>Publicado</source>
         <translation>Kiadta</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="987"/>
+        <location filename="../../src/funciones.cpp" line="989"/>
         <source>Edad recomendada</source>
         <translation>Ajánlott életkor</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="988"/>
+        <location filename="../../src/funciones.cpp" line="990"/>
         <source>Idioma</source>
         <translation>Nyelv</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="989"/>
+        <location filename="../../src/funciones.cpp" line="991"/>
         <source>Idioma voces</source>
         <translation>Nyelvi hangok</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="990"/>
+        <location filename="../../src/funciones.cpp" line="992"/>
         <source>Formato</source>
         <translation>Formátum</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="991"/>
+        <location filename="../../src/funciones.cpp" line="993"/>
         <source>Genero</source>
         <translation>Műfaj</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="992"/>
+        <location filename="../../src/funciones.cpp" line="994"/>
         <source>Tema</source>
         <translation>Téma</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="993"/>
+        <location filename="../../src/funciones.cpp" line="995"/>
         <source>Grupo</source>
         <translation>Csoport</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="994"/>
+        <location filename="../../src/funciones.cpp" line="996"/>
         <source>Perspectiva</source>
         <translation>Perspektíva</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="995"/>
+        <location filename="../../src/funciones.cpp" line="997"/>
         <source>Sistema operativo</source>
         <translation>Operációs rendszer</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="996"/>
+        <location filename="../../src/funciones.cpp" line="998"/>
         <source>Favorito</source>
         <translation>Kedvenc</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>Joystick</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>GamePad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="998"/>
+        <location filename="../../src/funciones.cpp" line="1000"/>
         <source>AÃ±adido el</source>
         <translation>Hozzáadva</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="999"/>
+        <location filename="../../src/funciones.cpp" line="1001"/>
         <source>GrÃ¡ficos</source>
         <translation>Grafika</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1000"/>
+        <location filename="../../src/funciones.cpp" line="1002"/>
         <source>Sonido</source>
         <translation>Hang</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1001"/>
+        <location filename="../../src/funciones.cpp" line="1003"/>
         <source>Jugabilidad</source>
         <translation>Játszhatóság</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1002"/>
+        <location filename="../../src/funciones.cpp" line="1004"/>
         <source>Original</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1003"/>
+        <location filename="../../src/funciones.cpp" line="1005"/>
         <source>Estado</source>
         <translation>Sztátusz</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1004"/>
+        <location filename="../../src/funciones.cpp" line="1006"/>
         <source>Tipo Emu</source>
         <translation>Emulátor típus</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1005"/>
+        <location filename="../../src/funciones.cpp" line="1007"/>
         <source>DescripciÃ³n</source>
         <translation>Leírás</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1006"/>
+        <location filename="../../src/funciones.cpp" line="1008"/>
         <source>Rating</source>
         <translation>Értékelés</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1007"/>
+        <location filename="../../src/funciones.cpp" line="1009"/>
         <source>NÂº discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1011"/>
+        <location filename="../../src/funciones.cpp" line="1013"/>
         <source>TÃ­tulo</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1012"/>
+        <location filename="../../src/funciones.cpp" line="1014"/>
         <source>TÃ­tulo album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1013"/>
+        <location filename="../../src/funciones.cpp" line="1015"/>
         <source>Artista album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1928"/>
+        <location filename="../../src/funciones.cpp" line="1930"/>
         <source>ConfiguraciÃ³n por defecto</source>
         <translation>Az alapértelmezett konfiguráció</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1933"/>
-        <location filename="../../src/funciones.cpp" line="1934"/>
+        <location filename="../../src/funciones.cpp" line="1935"/>
+        <location filename="../../src/funciones.cpp" line="1936"/>
         <source>Importar desde un archivo</source>
         <translation>Importálás fájlból</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1960"/>
+        <location filename="../../src/funciones.cpp" line="1962"/>
         <source>exterior</source>
         <translation>külső</translation>
     </message>
@@ -876,14 +876,14 @@
 <context>
     <name>GrLida</name>
     <message>
-        <location filename="../../src/grlida.cpp" line="1604"/>
+        <location filename="../../src/grlida.cpp" line="1616"/>
         <source>Por ID</source>
         <translation>ID szerint</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1985"/>
-        <location filename="../../src/grlida.cpp" line="1607"/>
-        <location filename="../../src/grlida.cpp" line="2035"/>
+        <location filename="../../src/grlida.cpp" line="1619"/>
+        <location filename="../../src/grlida.cpp" line="2047"/>
         <source>Genero</source>
         <translation>Műfaj</translation>
     </message>
@@ -1408,9 +1408,9 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1470"/>
-        <location filename="../../src/grlida.cpp" line="3835"/>
-        <location filename="../../src/grlida.cpp" line="3836"/>
-        <location filename="../../src/grlida.cpp" line="3837"/>
+        <location filename="../../src/grlida.cpp" line="3857"/>
+        <location filename="../../src/grlida.cpp" line="3858"/>
+        <location filename="../../src/grlida.cpp" line="3859"/>
         <source>PictureFlow como principal</source>
         <translation>PictureFlow mint a fő</translation>
     </message>
@@ -1430,7 +1430,7 @@
         <location filename="../../ui/grlida.ui" line="1679"/>
         <location filename="../../ui/grlida.ui" line="1769"/>
         <location filename="../../ui/grlida.ui" line="1772"/>
-        <location filename="../../src/grlida.cpp" line="3303"/>
+        <location filename="../../src/grlida.cpp" line="3325"/>
         <source>Archivos</source>
         <translation>Fájlok</translation>
     </message>
@@ -1602,7 +1602,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1969"/>
-        <location filename="../../src/grlida.cpp" line="2032"/>
+        <location filename="../../src/grlida.cpp" line="2044"/>
         <source>Icono</source>
         <translation>Ikonok</translation>
     </message>
@@ -1618,35 +1618,35 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2001"/>
-        <location filename="../../src/grlida.cpp" line="1609"/>
-        <location filename="../../src/grlida.cpp" line="2037"/>
+        <location filename="../../src/grlida.cpp" line="1621"/>
+        <location filename="../../src/grlida.cpp" line="2049"/>
         <source>Desarrollador</source>
         <translation>Fejlesztő</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2009"/>
-        <location filename="../../src/grlida.cpp" line="1610"/>
-        <location filename="../../src/grlida.cpp" line="2038"/>
+        <location filename="../../src/grlida.cpp" line="1622"/>
+        <location filename="../../src/grlida.cpp" line="2050"/>
         <source>Tema</source>
         <translation>Téma</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2017"/>
-        <location filename="../../src/grlida.cpp" line="2039"/>
+        <location filename="../../src/grlida.cpp" line="2051"/>
         <source>Grupo</source>
         <translation>Csoport</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2033"/>
-        <location filename="../../src/grlida.cpp" line="1611"/>
-        <location filename="../../src/grlida.cpp" line="2041"/>
+        <location filename="../../src/grlida.cpp" line="1623"/>
+        <location filename="../../src/grlida.cpp" line="2053"/>
         <source>Idioma</source>
         <translation>Nyelv</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2049"/>
-        <location filename="../../src/grlida.cpp" line="1612"/>
-        <location filename="../../src/grlida.cpp" line="2043"/>
+        <location filename="../../src/grlida.cpp" line="1624"/>
+        <location filename="../../src/grlida.cpp" line="2055"/>
         <source>Formato</source>
         <translation>Formátum</translation>
     </message>
@@ -1657,7 +1657,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2073"/>
-        <location filename="../../src/grlida.cpp" line="2046"/>
+        <location filename="../../src/grlida.cpp" line="2058"/>
         <source>Sistema</source>
         <translation>Operációs rendszer</translation>
     </message>
@@ -1683,13 +1683,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2170"/>
-        <location filename="../../src/grlida.cpp" line="2057"/>
+        <location filename="../../src/grlida.cpp" line="2069"/>
         <source>Edad</source>
         <translation>Életkor</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2178"/>
-        <location filename="../../src/grlida.cpp" line="2058"/>
+        <location filename="../../src/grlida.cpp" line="2070"/>
         <source>Usuario</source>
         <translation>Felhasználónév</translation>
     </message>
@@ -1803,7 +1803,7 @@
         <translation>Tartalmaz fájlokat / borítókat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3295"/>
+        <location filename="../../src/grlida.cpp" line="3317"/>
         <source>Capturas de sonidos</source>
         <translation>Hang felvételek</translation>
     </message>
@@ -1860,48 +1860,48 @@
         <translation>&amp;Helyreállítás</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1615"/>
+        <location filename="../../src/grlida.cpp" line="1627"/>
         <source>Sistema OS</source>
         <translation>Operációs rendszer</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2097"/>
-        <location filename="../../src/grlida.cpp" line="1617"/>
-        <location filename="../../src/grlida.cpp" line="2049"/>
+        <location filename="../../src/grlida.cpp" line="1629"/>
+        <location filename="../../src/grlida.cpp" line="2061"/>
         <source>Sonido</source>
         <translation>Hang</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2105"/>
-        <location filename="../../src/grlida.cpp" line="1618"/>
-        <location filename="../../src/grlida.cpp" line="2050"/>
+        <location filename="../../src/grlida.cpp" line="1630"/>
+        <location filename="../../src/grlida.cpp" line="2062"/>
         <source>Jugabilidad</source>
         <translation>Játszhatóság</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2113"/>
-        <location filename="../../src/grlida.cpp" line="1619"/>
-        <location filename="../../src/grlida.cpp" line="2051"/>
+        <location filename="../../src/grlida.cpp" line="1631"/>
+        <location filename="../../src/grlida.cpp" line="2063"/>
         <source>Original</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1620"/>
-        <location filename="../../src/grlida.cpp" line="2295"/>
+        <location filename="../../src/grlida.cpp" line="1632"/>
+        <location filename="../../src/grlida.cpp" line="2307"/>
         <source>Tipo emulador</source>
         <translation>Emuláció típus</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2151"/>
-        <location filename="../../src/grlida.cpp" line="1621"/>
-        <location filename="../../src/grlida.cpp" line="2055"/>
+        <location filename="../../src/grlida.cpp" line="1633"/>
+        <location filename="../../src/grlida.cpp" line="2067"/>
         <source>Favorito</source>
         <translation>Kedvenc</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2162"/>
-        <location filename="../../src/grlida.cpp" line="1622"/>
-        <location filename="../../src/grlida.cpp" line="2056"/>
+        <location filename="../../src/grlida.cpp" line="1634"/>
+        <location filename="../../src/grlida.cpp" line="2068"/>
         <source>Rating</source>
         <translation>Értékelés</translation>
     </message>
@@ -1911,12 +1911,12 @@
         <translation>által</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1626"/>
+        <location filename="../../src/grlida.cpp" line="1638"/>
         <source>Ascendente</source>
         <translation>Növekvő</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1627"/>
+        <location filename="../../src/grlida.cpp" line="1639"/>
         <source>Descendente</source>
         <translation>Csökkenő</translation>
     </message>
@@ -1926,17 +1926,17 @@
         <translation>Rendez</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2289"/>
+        <location filename="../../src/grlida.cpp" line="2301"/>
         <source>Todos</source>
         <translation>Mind</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2290"/>
+        <location filename="../../src/grlida.cpp" line="2302"/>
         <source>Favoritos</source>
         <translation>Kedvencek</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2291"/>
+        <location filename="../../src/grlida.cpp" line="2303"/>
         <source>Originales</source>
         <translation>Eredeti</translation>
     </message>
@@ -1946,31 +1946,31 @@
         <translation>Hiba történt az adatbázis megnyitásakor</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2526"/>
+        <location filename="../../src/grlida.cpp" line="2540"/>
         <source>Datos</source>
         <translation>Adat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2558"/>
+        <location filename="../../src/grlida.cpp" line="2572"/>
         <source>Otro emulador</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3807"/>
-        <location filename="../../src/grlida.cpp" line="3808"/>
-        <location filename="../../src/grlida.cpp" line="3809"/>
+        <location filename="../../src/grlida.cpp" line="3829"/>
+        <location filename="../../src/grlida.cpp" line="3830"/>
+        <location filename="../../src/grlida.cpp" line="3831"/>
         <source>Ver lista de juegos</source>
         <translation>Lásd játékok listája</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3810"/>
+        <location filename="../../src/grlida.cpp" line="3832"/>
         <source>Lista de juegos</source>
         <translation>Játékok listája</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3813"/>
-        <location filename="../../src/grlida.cpp" line="3814"/>
-        <location filename="../../src/grlida.cpp" line="3815"/>
+        <location filename="../../src/grlida.cpp" line="3835"/>
+        <location filename="../../src/grlida.cpp" line="3836"/>
+        <location filename="../../src/grlida.cpp" line="3837"/>
         <source>Lista de juegos como principal</source>
         <translation>Játékok listája, mint a fő</translation>
     </message>
@@ -1981,13 +1981,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2025"/>
-        <location filename="../../src/grlida.cpp" line="2040"/>
+        <location filename="../../src/grlida.cpp" line="2052"/>
         <source>Perspectiva</source>
         <translation>Perspektíva</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2121"/>
-        <location filename="../../src/grlida.cpp" line="2052"/>
+        <location filename="../../src/grlida.cpp" line="2064"/>
         <source>Estado</source>
         <translation>Sztátusz</translation>
     </message>
@@ -2003,286 +2003,286 @@ Ez az alkalmazás SQLite-ot kér. Olvassa el a Qt-SQL driver dokumentumot több 
 Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1605"/>
-        <location filename="../../src/grlida.cpp" line="2033"/>
+        <location filename="../../src/grlida.cpp" line="1617"/>
+        <location filename="../../src/grlida.cpp" line="2045"/>
         <source>TÃ­tulo</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1608"/>
-        <location filename="../../src/grlida.cpp" line="2036"/>
+        <location filename="../../src/grlida.cpp" line="1620"/>
+        <location filename="../../src/grlida.cpp" line="2048"/>
         <source>CompaÃ±ia</source>
         <translation>Kiadó</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1613"/>
-        <location filename="../../src/grlida.cpp" line="2044"/>
+        <location filename="../../src/grlida.cpp" line="1625"/>
+        <location filename="../../src/grlida.cpp" line="2056"/>
         <source>AÃ±o</source>
         <translation>Év</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1614"/>
+        <location filename="../../src/grlida.cpp" line="1626"/>
         <source>NÂº discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1616"/>
-        <location filename="../../src/grlida.cpp" line="2048"/>
+        <location filename="../../src/grlida.cpp" line="1628"/>
+        <location filename="../../src/grlida.cpp" line="2060"/>
         <source>GrÃ¡ficos</source>
         <translation>Grafika</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2054"/>
+        <location filename="../../src/grlida.cpp" line="2066"/>
         <source>Tipo Emu</source>
         <translation>Emulátor típus</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2047"/>
+        <location filename="../../src/grlida.cpp" line="2059"/>
         <source>TamaÃ±o</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>de</source>
         <translation>a/az</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>NÂº juegos</source>
         <translation>Játékok száma</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1537"/>
+        <location filename="../../src/grlida.cpp" line="1549"/>
         <source>InformaciÃ³n no disponible</source>
         <translation>Információ nem áll rendelkezésre</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2683"/>
+        <location filename="../../src/grlida.cpp" line="2705"/>
         <source>introducido el</source>
         <translation>Bevezette</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3216"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3238"/>
         <source>Si</source>
         <translation>Igen</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1606"/>
-        <location filename="../../src/grlida.cpp" line="2034"/>
+        <location filename="../../src/grlida.cpp" line="1618"/>
+        <location filename="../../src/grlida.cpp" line="2046"/>
         <source>SubtÃ­tulo</source>
         <translation>Alcím</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1924"/>
+        <location filename="../../src/grlida.cpp" line="1936"/>
         <source>The file is not an XBEL version 1.0 file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Actualizaciones</source>
         <translation>Updates</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>No existen actualizaciones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Mostrar</source>
         <translation>Show</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Aceptar</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2042"/>
+        <location filename="../../src/grlida.cpp" line="2054"/>
         <source>Idioma Voces</source>
         <translation>Nyelvi hangok</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2045"/>
+        <location filename="../../src/grlida.cpp" line="2057"/>
         <source>NÂº Discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2053"/>
+        <location filename="../../src/grlida.cpp" line="2065"/>
         <source>Fecha</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3221"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3243"/>
         <source>No</source>
         <translation>Nem</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3157"/>
+        <location filename="../../src/grlida.cpp" line="3179"/>
         <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3161"/>
+        <location filename="../../src/grlida.cpp" line="3183"/>
         <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3162"/>
+        <location filename="../../src/grlida.cpp" line="3184"/>
         <source>Ademas borrara lo marcado siempre y cuando este dentro del directorio del GR-lida.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3177"/>
+        <location filename="../../src/grlida.cpp" line="3199"/>
         <source>Eliminar carÃ¡tula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3181"/>
+        <location filename="../../src/grlida.cpp" line="3203"/>
         <source>Eliminar imÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3186"/>
+        <location filename="../../src/grlida.cpp" line="3208"/>
         <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3190"/>
+        <location filename="../../src/grlida.cpp" line="3212"/>
         <source>Eliminar capturas de pantalla.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3194"/>
+        <location filename="../../src/grlida.cpp" line="3216"/>
         <source>Eliminar imÃ¡genes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3198"/>
+        <location filename="../../src/grlida.cpp" line="3220"/>
         <source>Eliminar capturas de sonido.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3202"/>
+        <location filename="../../src/grlida.cpp" line="3224"/>
         <source>Eliminar capturas de video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3206"/>
+        <location filename="../../src/grlida.cpp" line="3228"/>
         <source>Eliminar archivos guardados.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3253"/>
+        <location filename="../../src/grlida.cpp" line="3275"/>
         <source>CarÃ¡tula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3260"/>
+        <location filename="../../src/grlida.cpp" line="3282"/>
         <source>ImÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3272"/>
+        <location filename="../../src/grlida.cpp" line="3294"/>
         <source>Capturas de pantalla</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3279"/>
+        <location filename="../../src/grlida.cpp" line="3301"/>
         <source>ImÃ¡genes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3287"/>
+        <location filename="../../src/grlida.cpp" line="3309"/>
         <source>Capturas de videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3313"/>
+        <location filename="../../src/grlida.cpp" line="3335"/>
         <source>ConfiguraciÃ³n de DOSBox</source>
         <translation>DOSBox konfiguráció</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3331"/>
+        <location filename="../../src/grlida.cpp" line="3353"/>
         <source>ConfiguraciÃ³n de ScummVM</source>
         <translation>ScummVM konfiguráció</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3339"/>
+        <location filename="../../src/grlida.cpp" line="3361"/>
         <source>ConfiguraciÃ³n de VDMSound</source>
         <translation>VDMSound konfiguráció</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>El juego ha sido eliminado correctamente</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>Ha borrado</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3505"/>
+        <location filename="../../src/grlida.cpp" line="3527"/>
         <source>Ejecutar</source>
         <translation>Futtatás</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4816"/>
+        <location filename="../../src/grlida.cpp" line="4838"/>
         <source>Se ha producido un error al salir del proceso</source>
         <translation>Hiba történt a folyamatból</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4841"/>
+        <location filename="../../src/grlida.cpp" line="4863"/>
         <source>Se ha producido un error al iniciar el proceso de inicio</source>
         <translation>Hiba kezdve a rendszerindítási folyamat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4844"/>
+        <location filename="../../src/grlida.cpp" line="4866"/>
         <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
         <translation>Hiba történt a folyamat, miután sikeresen megkezdése</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4847"/>
+        <location filename="../../src/grlida.cpp" line="4869"/>
         <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
         <translation>Hiba történt waitfor ... () Legutóbb out funkció</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4850"/>
+        <location filename="../../src/grlida.cpp" line="4872"/>
         <source>Se ha producido un error al intentar escribir en el proceso de inicio</source>
         <translation>Hiba próbál írni a rendszerindítási folyamat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4853"/>
+        <location filename="../../src/grlida.cpp" line="4875"/>
         <source>Se ha producido un error al intentar leer en el proceso</source>
         <translation>Hiba beolvasása közben a folyamat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4856"/>
+        <location filename="../../src/grlida.cpp" line="4878"/>
         <source>Ha ocurrido un error desconocido</source>
         <translation>Ismeretlen hiba történt</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3127"/>
-        <location filename="../../src/grlida.cpp" line="3388"/>
+        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3410"/>
         <source>Por favor selecciona un juego de la lista para eliminarlo</source>
         <translation>Kérem válasszon ki egy játékot a listából amit törölni szeretne</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3171"/>
         <source>Â¿Eliminar juego...?</source>
         <translation>Játék törlése...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3014"/>
+        <location filename="../../src/grlida.cpp" line="3036"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>Az emulátor indítófájlja nem található.
@@ -2588,37 +2588,37 @@ Please check the media service plugins are installed.</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="825"/>
+        <location filename="../../src/dbsql.cpp" line="859"/>
         <source>Generos</source>
         <translation>Műfaj</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="826"/>
+        <location filename="../../src/dbsql.cpp" line="860"/>
         <source>Temas</source>
         <translation>Téma</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="827"/>
+        <location filename="../../src/dbsql.cpp" line="861"/>
         <source>Desarrolladores</source>
         <translation>Fejlesztők</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="828"/>
+        <location filename="../../src/dbsql.cpp" line="862"/>
         <source>CompaÃ±ias</source>
         <translation>Kiadó</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="829"/>
+        <location filename="../../src/dbsql.cpp" line="863"/>
         <source>AÃ±os</source>
         <translation>Év</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="830"/>
+        <location filename="../../src/dbsql.cpp" line="864"/>
         <source>Idiomas</source>
         <translation>Nyelv</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="849"/>
+        <location filename="../../src/dbsql.cpp" line="883"/>
         <source>Todos</source>
         <translation>Mind</translation>
     </message>
@@ -2748,11 +2748,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Selecciona un archivo</source>
         <translation>Válasszon ki egy fájlt</translation>
     </message>
@@ -2765,11 +2765,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Todos los archivos</source>
         <translation>Összes fájlok</translation>
     </message>
@@ -2794,19 +2794,19 @@ Please check the media service plugins are installed.</source>
         <translation>Szeretné e törölni ezt a csatolást?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1215"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1222"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1229"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1209"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1216"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1223"/>
         <source>Seleccionar un directorio</source>
         <translation>Válasszon ki egy könyvtárat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Idioma</source>
         <translation>Nyelv</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
         <source>Imagen</source>
         <translation>Kép</translation>
     </message>
@@ -2816,12 +2816,12 @@ Please check the media service plugins are installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
         <source>Imagen CD</source>
         <translation>Kép CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
         <source>Imagen HD</source>
         <translation>Kép HD</translation>
     </message>
@@ -4358,121 +4358,130 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="64"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>ISO, CUE/BIN képfájl</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
         <source>Imagen ISO multiples</source>
         <translation>Többszörös ISO képfájlok</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
         <source>Imagen de disco duro</source>
         <translation>Merevlemez képfájl</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="68"/>
         <source>Imagen Botable</source>
         <translation>Bootolható képfájl</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="70"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <source>No usar nada</source>
         <translation>Ne használj semmit</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Usar</source>
         <translation>Használ</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
         <translation>Force ASPI layer usage. Only Windows with ASPI-Layer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
         <translation>Automatic Audio CD interface</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio extraction for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <source>Llamadas ioctl utiliza para CD de audio</source>
         <translation>IOCTL calls for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
         <source>MCI utiliza para CD de audio</source>
         <translation>Use MCI for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
         <translation>Force SDL for CD-ROM. Available in all systems</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="87"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="88"/>
         <source>NO usar CD</source>
         <translation>Ne csatoljon CD-t</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="272"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="273"/>
         <source>Seleccionar un directorio</source>
         <translation>Válasszon ki egy könyvtárat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Todos los archivos</source>
         <translation>Összes fájlok</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
         <source>Â¿Eliminar...?</source>
         <translation>Törlés...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Szeretné törölni az ISO képfájlt a listaból?</translation>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="397"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Szeretné törölni az ISO képfájlt a listaból?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="398"/>
         <source>Espacio libre virtual (%1 %2)</source>
         <translation>Virtual free space (%1 %2)</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>Procura no montar la Raiz del sistema operativo: ejemplo en windows seria</source>
         <translation>Próbálja meg mellőzni az operációs rendszer könyvtárbeli csatolást: egy példa erre a Windows könyvtár</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>y en linux seria directamente</source>
         <translation>és linuxban így lenne</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="281"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="282"/>
         <source>Imagen</source>
         <translation>Kép</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="283"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="284"/>
         <source>Imagen CD</source>
         <translation>Kép CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Selecciona un archivo</source>
         <translation>Válasszon ki egy könyvtárat</translation>
     </message>
@@ -6670,69 +6679,78 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="86"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>ISO, CUE/BIN képfájl</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
         <source>Imagen ISO multiples</source>
         <translation>Többszörös ISO képfájlok</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="89"/>
         <source>Imagen de disco duro</source>
         <translation>Merevlemez képfájl</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="168"/>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="252"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="169"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="253"/>
         <source>Seleccionar un directorio</source>
         <translation>Válasszon ki egy könyvtárat</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Todos los archivos</source>
         <translation>Összes fájlok</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
         <source>Â¿Eliminar...?</source>
         <translation>Törlés...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>Szeretné törölni az ISO képfájlt a listaból?</translation>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="282"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">Szeretné törölni az ISO képfájlt a listaból?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="283"/>
         <source>El ejecutable suele ser: INSTALL, si no esta seguro teclee DIR y pulsa INTRO</source>
         <translation>A program indítófájlja általában INSTALL. Ha nem biztos benne, írja be,hogy DIR és üssön ENTER-t</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="347"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="355"/>
         <source>Puede que no este disponible el ejecutable del emulador.
 O el directorio de destino.</source>
         <translation>Vagy az emulátor programfájlai nem elérhetőek, 
 vagy a cél könyvtár hibás.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="177"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="178"/>
         <source>Imagen</source>
         <translation>Kép</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="179"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="180"/>
         <source>Imagen CD</source>
         <translation>Kép CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Selecciona un archivo</source>
         <translation>Válasszon ki egy fájlt</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="131"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="132"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>Az emulátor indítófájljai nem találhatóak.
@@ -7483,6 +7501,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <translation>Címke</translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="2440"/>
         <location filename="../../src/grlida_opciones.cpp" line="2490"/>
         <location filename="../../src/grlida_opciones.cpp" line="2508"/>
         <source>Config</source>
@@ -7800,6 +7819,51 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="174"/>
+        <source>Cada veinticuatro horas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="175"/>
+        <source>Semanalmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="176"/>
+        <source>Mensualmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="202"/>
+        <location filename="../../src/grlida_opciones.cpp" line="246"/>
+        <location filename="../../src/grlida_opciones.cpp" line="283"/>
+        <location filename="../../src/grlida_opciones.cpp" line="316"/>
+        <location filename="../../src/grlida_opciones.cpp" line="342"/>
+        <location filename="../../src/grlida_opciones.cpp" line="391"/>
+        <location filename="../../src/grlida_opciones.cpp" line="498"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2427"/>
+        <source>ImÃ¡genes CategorÃ­as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="249"/>
+        <location filename="../../src/grlida_opciones.cpp" line="286"/>
+        <location filename="../../src/grlida_opciones.cpp" line="319"/>
+        <location filename="../../src/grlida_opciones.cpp" line="345"/>
+        <location filename="../../src/grlida_opciones.cpp" line="394"/>
+        <location filename="../../src/grlida_opciones.cpp" line="501"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2429"/>
+        <source>ImÃ¡genes defecto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="322"/>
+        <location filename="../../src/grlida_opciones.cpp" line="348"/>
+        <location filename="../../src/grlida_opciones.cpp" line="504"/>
+        <source>ImÃ¡genes idiomas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/grlida_opciones.cpp" line="555"/>
         <source>Thumb en JPG</source>
         <translation type="unfinished"></translation>
@@ -7957,6 +8021,13 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2836"/>
         <source>Color de texto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="3075"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3105"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3135"/>
+        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8917,7 +8988,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     <message>
         <location filename="../../ui/update.ui" line="20"/>
         <location filename="../../ui/update.ui" line="64"/>
-        <location filename="../../src/grlida_update.cpp" line="108"/>
+        <location filename="../../src/grlida_update.cpp" line="121"/>
         <source>Actualizaciones</source>
         <translation>Updates</translation>
     </message>
@@ -8942,27 +9013,27 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="64"/>
+        <location filename="../../src/grlida_update.cpp" line="74"/>
         <source>Estilos o themes para el GR-lida</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Descargar</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Actualizar</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="70"/>
+        <location filename="../../src/grlida_update.cpp" line="82"/>
         <source>Lista de compatibilidad del ScummVM</source>
         <translation>ScummVM compatibility list</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="58"/>
+        <location filename="../../src/grlida_update.cpp" line="65"/>
         <source>Script para importar datos del juego</source>
         <translation>Script to import game data</translation>
     </message>

--- a/res/idiomas/gr-lida_ru_RU.ts
+++ b/res/idiomas/gr-lida_ru_RU.ts
@@ -241,188 +241,188 @@
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="978"/>
+        <location filename="../../src/funciones.cpp" line="980"/>
         <source>CarÃ¡tula frontal</source>
         <translation>Передняя обложка</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="979"/>
+        <location filename="../../src/funciones.cpp" line="981"/>
         <source>Detalles del juego</source>
         <translation>Описание игры</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="980"/>
+        <location filename="../../src/funciones.cpp" line="982"/>
         <source>CalificaciÃ³n</source>
         <translation>Рейтинг</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="981"/>
+        <location filename="../../src/funciones.cpp" line="983"/>
         <source>Otros datos</source>
         <translation>Прочие данные</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="982"/>
+        <location filename="../../src/funciones.cpp" line="984"/>
         <source>Subido por</source>
         <translation>Загружена</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="983"/>
+        <location filename="../../src/funciones.cpp" line="985"/>
         <source>SubtÃ­tulo</source>
         <translation>Подзаголовок</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="984"/>
+        <location filename="../../src/funciones.cpp" line="986"/>
         <source>Publicado por</source>
         <translation>Опубликована</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="985"/>
+        <location filename="../../src/funciones.cpp" line="987"/>
         <source>Desarrollado por</source>
         <translation>Разработана</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="986"/>
+        <location filename="../../src/funciones.cpp" line="988"/>
         <source>Publicado</source>
         <translation>Опубликована</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="987"/>
+        <location filename="../../src/funciones.cpp" line="989"/>
         <source>Edad recomendada</source>
         <translation>Возраст</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="988"/>
+        <location filename="../../src/funciones.cpp" line="990"/>
         <source>Idioma</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="989"/>
+        <location filename="../../src/funciones.cpp" line="991"/>
         <source>Idioma voces</source>
         <translation>Язык озвучки</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="990"/>
+        <location filename="../../src/funciones.cpp" line="992"/>
         <source>Formato</source>
         <translation>Формат</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="991"/>
+        <location filename="../../src/funciones.cpp" line="993"/>
         <source>Genero</source>
         <translation>Жанр</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="992"/>
+        <location filename="../../src/funciones.cpp" line="994"/>
         <source>Tema</source>
         <translation>Тема</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="993"/>
+        <location filename="../../src/funciones.cpp" line="995"/>
         <source>Grupo</source>
         <translation>группа</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="994"/>
+        <location filename="../../src/funciones.cpp" line="996"/>
         <source>Perspectiva</source>
         <translation>Перспектива</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="995"/>
+        <location filename="../../src/funciones.cpp" line="997"/>
         <source>Sistema operativo</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="996"/>
+        <location filename="../../src/funciones.cpp" line="998"/>
         <source>Favorito</source>
         <translation>В избранном</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>Joystick</source>
         <translation>Джойстик</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="997"/>
+        <location filename="../../src/funciones.cpp" line="999"/>
         <source>GamePad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="998"/>
+        <location filename="../../src/funciones.cpp" line="1000"/>
         <source>AÃ±adido el</source>
         <translation>Добалена</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="999"/>
+        <location filename="../../src/funciones.cpp" line="1001"/>
         <source>GrÃ¡ficos</source>
         <translation>Графика</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1000"/>
+        <location filename="../../src/funciones.cpp" line="1002"/>
         <source>Sonido</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1001"/>
+        <location filename="../../src/funciones.cpp" line="1003"/>
         <source>Jugabilidad</source>
         <translation>Играбельность</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1002"/>
+        <location filename="../../src/funciones.cpp" line="1004"/>
         <source>Original</source>
         <translation>Оригинальная</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1003"/>
+        <location filename="../../src/funciones.cpp" line="1005"/>
         <source>Estado</source>
         <translation>Статус</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1004"/>
+        <location filename="../../src/funciones.cpp" line="1006"/>
         <source>Tipo Emu</source>
         <translation>Тип эмуляции</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1005"/>
+        <location filename="../../src/funciones.cpp" line="1007"/>
         <source>DescripciÃ³n</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1006"/>
+        <location filename="../../src/funciones.cpp" line="1008"/>
         <source>Rating</source>
         <translation>Рейтинг</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1007"/>
+        <location filename="../../src/funciones.cpp" line="1009"/>
         <source>NÂº discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1011"/>
+        <location filename="../../src/funciones.cpp" line="1013"/>
         <source>TÃ­tulo</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1012"/>
+        <location filename="../../src/funciones.cpp" line="1014"/>
         <source>TÃ­tulo album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1013"/>
+        <location filename="../../src/funciones.cpp" line="1015"/>
         <source>Artista album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1928"/>
+        <location filename="../../src/funciones.cpp" line="1930"/>
         <source>ConfiguraciÃ³n por defecto</source>
         <translation>Default configuration</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1933"/>
-        <location filename="../../src/funciones.cpp" line="1934"/>
+        <location filename="../../src/funciones.cpp" line="1935"/>
+        <location filename="../../src/funciones.cpp" line="1936"/>
         <source>Importar desde un archivo</source>
         <translation>Импортировать из файла</translation>
     </message>
     <message>
-        <location filename="../../src/funciones.cpp" line="1960"/>
+        <location filename="../../src/funciones.cpp" line="1962"/>
         <source>exterior</source>
         <translation>external</translation>
     </message>
@@ -876,14 +876,14 @@
 <context>
     <name>GrLida</name>
     <message>
-        <location filename="../../src/grlida.cpp" line="1604"/>
+        <location filename="../../src/grlida.cpp" line="1616"/>
         <source>Por ID</source>
         <translation>По ID</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1985"/>
-        <location filename="../../src/grlida.cpp" line="1607"/>
-        <location filename="../../src/grlida.cpp" line="2035"/>
+        <location filename="../../src/grlida.cpp" line="1619"/>
+        <location filename="../../src/grlida.cpp" line="2047"/>
         <source>Genero</source>
         <translation>Жанр</translation>
     </message>
@@ -1408,9 +1408,9 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1470"/>
-        <location filename="../../src/grlida.cpp" line="3835"/>
-        <location filename="../../src/grlida.cpp" line="3836"/>
-        <location filename="../../src/grlida.cpp" line="3837"/>
+        <location filename="../../src/grlida.cpp" line="3857"/>
+        <location filename="../../src/grlida.cpp" line="3858"/>
+        <location filename="../../src/grlida.cpp" line="3859"/>
         <source>PictureFlow como principal</source>
         <translation>PictureFlow set as main</translation>
     </message>
@@ -1430,7 +1430,7 @@
         <location filename="../../ui/grlida.ui" line="1679"/>
         <location filename="../../ui/grlida.ui" line="1769"/>
         <location filename="../../ui/grlida.ui" line="1772"/>
-        <location filename="../../src/grlida.cpp" line="3303"/>
+        <location filename="../../src/grlida.cpp" line="3325"/>
         <source>Archivos</source>
         <translation>Файлы</translation>
     </message>
@@ -1602,7 +1602,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="1969"/>
-        <location filename="../../src/grlida.cpp" line="2032"/>
+        <location filename="../../src/grlida.cpp" line="2044"/>
         <source>Icono</source>
         <translation>Иконки</translation>
     </message>
@@ -1618,35 +1618,35 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2001"/>
-        <location filename="../../src/grlida.cpp" line="1609"/>
-        <location filename="../../src/grlida.cpp" line="2037"/>
+        <location filename="../../src/grlida.cpp" line="1621"/>
+        <location filename="../../src/grlida.cpp" line="2049"/>
         <source>Desarrollador</source>
         <translation>Разработчик</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2009"/>
-        <location filename="../../src/grlida.cpp" line="1610"/>
-        <location filename="../../src/grlida.cpp" line="2038"/>
+        <location filename="../../src/grlida.cpp" line="1622"/>
+        <location filename="../../src/grlida.cpp" line="2050"/>
         <source>Tema</source>
         <translation>Тема</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2017"/>
-        <location filename="../../src/grlida.cpp" line="2039"/>
+        <location filename="../../src/grlida.cpp" line="2051"/>
         <source>Grupo</source>
         <translation>группа</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2033"/>
-        <location filename="../../src/grlida.cpp" line="1611"/>
-        <location filename="../../src/grlida.cpp" line="2041"/>
+        <location filename="../../src/grlida.cpp" line="1623"/>
+        <location filename="../../src/grlida.cpp" line="2053"/>
         <source>Idioma</source>
         <translation>Язык</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2049"/>
-        <location filename="../../src/grlida.cpp" line="1612"/>
-        <location filename="../../src/grlida.cpp" line="2043"/>
+        <location filename="../../src/grlida.cpp" line="1624"/>
+        <location filename="../../src/grlida.cpp" line="2055"/>
         <source>Formato</source>
         <translation>Формат</translation>
     </message>
@@ -1657,7 +1657,7 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2073"/>
-        <location filename="../../src/grlida.cpp" line="2046"/>
+        <location filename="../../src/grlida.cpp" line="2058"/>
         <source>Sistema</source>
         <translation>Система</translation>
     </message>
@@ -1683,13 +1683,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2170"/>
-        <location filename="../../src/grlida.cpp" line="2057"/>
+        <location filename="../../src/grlida.cpp" line="2069"/>
         <source>Edad</source>
         <translation>Возраст</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2178"/>
-        <location filename="../../src/grlida.cpp" line="2058"/>
+        <location filename="../../src/grlida.cpp" line="2070"/>
         <source>Usuario</source>
         <translation>Имя пользователя</translation>
     </message>
@@ -1803,7 +1803,7 @@
         <translation>Есть файлы/оболжки</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3295"/>
+        <location filename="../../src/grlida.cpp" line="3317"/>
         <source>Capturas de sonidos</source>
         <translation>Захваченный звук</translation>
     </message>
@@ -1860,48 +1860,48 @@
         <translation>Восстановить</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1615"/>
+        <location filename="../../src/grlida.cpp" line="1627"/>
         <source>Sistema OS</source>
         <translation>Система</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2097"/>
-        <location filename="../../src/grlida.cpp" line="1617"/>
-        <location filename="../../src/grlida.cpp" line="2049"/>
+        <location filename="../../src/grlida.cpp" line="1629"/>
+        <location filename="../../src/grlida.cpp" line="2061"/>
         <source>Sonido</source>
         <translation>Звук</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2105"/>
-        <location filename="../../src/grlida.cpp" line="1618"/>
-        <location filename="../../src/grlida.cpp" line="2050"/>
+        <location filename="../../src/grlida.cpp" line="1630"/>
+        <location filename="../../src/grlida.cpp" line="2062"/>
         <source>Jugabilidad</source>
         <translation>Играбельность</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2113"/>
-        <location filename="../../src/grlida.cpp" line="1619"/>
-        <location filename="../../src/grlida.cpp" line="2051"/>
+        <location filename="../../src/grlida.cpp" line="1631"/>
+        <location filename="../../src/grlida.cpp" line="2063"/>
         <source>Original</source>
         <translation>Оригинальная</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1620"/>
-        <location filename="../../src/grlida.cpp" line="2295"/>
+        <location filename="../../src/grlida.cpp" line="1632"/>
+        <location filename="../../src/grlida.cpp" line="2307"/>
         <source>Tipo emulador</source>
         <translation>Тип эмуляции</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2151"/>
-        <location filename="../../src/grlida.cpp" line="1621"/>
-        <location filename="../../src/grlida.cpp" line="2055"/>
+        <location filename="../../src/grlida.cpp" line="1633"/>
+        <location filename="../../src/grlida.cpp" line="2067"/>
         <source>Favorito</source>
         <translation>В избранном</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2162"/>
-        <location filename="../../src/grlida.cpp" line="1622"/>
-        <location filename="../../src/grlida.cpp" line="2056"/>
+        <location filename="../../src/grlida.cpp" line="1634"/>
+        <location filename="../../src/grlida.cpp" line="2068"/>
         <source>Rating</source>
         <translation>Рейтинг</translation>
     </message>
@@ -1911,12 +1911,12 @@
         <translation>на</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1626"/>
+        <location filename="../../src/grlida.cpp" line="1638"/>
         <source>Ascendente</source>
         <translation>По возрастанию</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1627"/>
+        <location filename="../../src/grlida.cpp" line="1639"/>
         <source>Descendente</source>
         <translation>По убыванию</translation>
     </message>
@@ -1926,17 +1926,17 @@
         <translation>Сортировка</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2289"/>
+        <location filename="../../src/grlida.cpp" line="2301"/>
         <source>Todos</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2290"/>
+        <location filename="../../src/grlida.cpp" line="2302"/>
         <source>Favoritos</source>
         <translation>Избранные</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2291"/>
+        <location filename="../../src/grlida.cpp" line="2303"/>
         <source>Originales</source>
         <translation>Оригинальные</translation>
     </message>
@@ -1946,31 +1946,31 @@
         <translation>Ошибка при открытии базы данных</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2526"/>
+        <location filename="../../src/grlida.cpp" line="2540"/>
         <source>Datos</source>
         <translation>Данные</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2558"/>
+        <location filename="../../src/grlida.cpp" line="2572"/>
         <source>Otro emulador</source>
         <translation>Other emulators</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3807"/>
-        <location filename="../../src/grlida.cpp" line="3808"/>
-        <location filename="../../src/grlida.cpp" line="3809"/>
+        <location filename="../../src/grlida.cpp" line="3829"/>
+        <location filename="../../src/grlida.cpp" line="3830"/>
+        <location filename="../../src/grlida.cpp" line="3831"/>
         <source>Ver lista de juegos</source>
         <translation>Show list games</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3810"/>
+        <location filename="../../src/grlida.cpp" line="3832"/>
         <source>Lista de juegos</source>
         <translation>List games</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3813"/>
-        <location filename="../../src/grlida.cpp" line="3814"/>
-        <location filename="../../src/grlida.cpp" line="3815"/>
+        <location filename="../../src/grlida.cpp" line="3835"/>
+        <location filename="../../src/grlida.cpp" line="3836"/>
+        <location filename="../../src/grlida.cpp" line="3837"/>
         <source>Lista de juegos como principal</source>
         <translation>List of games set as main</translation>
     </message>
@@ -1981,13 +1981,13 @@
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2025"/>
-        <location filename="../../src/grlida.cpp" line="2040"/>
+        <location filename="../../src/grlida.cpp" line="2052"/>
         <source>Perspectiva</source>
         <translation>Перспектива</translation>
     </message>
     <message>
         <location filename="../../ui/grlida.ui" line="2121"/>
-        <location filename="../../src/grlida.cpp" line="2052"/>
+        <location filename="../../src/grlida.cpp" line="2064"/>
         <source>Estado</source>
         <translation>Статус</translation>
     </message>
@@ -2003,286 +2003,286 @@ Click cancelar para salir.</source>
 Нажмите на &apos;Отмена&apos; для выхода.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1605"/>
-        <location filename="../../src/grlida.cpp" line="2033"/>
+        <location filename="../../src/grlida.cpp" line="1617"/>
+        <location filename="../../src/grlida.cpp" line="2045"/>
         <source>TÃ­tulo</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1608"/>
-        <location filename="../../src/grlida.cpp" line="2036"/>
+        <location filename="../../src/grlida.cpp" line="1620"/>
+        <location filename="../../src/grlida.cpp" line="2048"/>
         <source>CompaÃ±ia</source>
         <translation>Компания</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1613"/>
-        <location filename="../../src/grlida.cpp" line="2044"/>
+        <location filename="../../src/grlida.cpp" line="1625"/>
+        <location filename="../../src/grlida.cpp" line="2056"/>
         <source>AÃ±o</source>
         <translation>Год</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1614"/>
+        <location filename="../../src/grlida.cpp" line="1626"/>
         <source>NÂº discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1616"/>
-        <location filename="../../src/grlida.cpp" line="2048"/>
+        <location filename="../../src/grlida.cpp" line="1628"/>
+        <location filename="../../src/grlida.cpp" line="2060"/>
         <source>GrÃ¡ficos</source>
         <translation>Графика</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2054"/>
+        <location filename="../../src/grlida.cpp" line="2066"/>
         <source>Tipo Emu</source>
         <translation>Тип эмуляции</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2047"/>
+        <location filename="../../src/grlida.cpp" line="2059"/>
         <source>TamaÃ±o</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>de</source>
         <translation>из</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2202"/>
-        <location filename="../../src/grlida.cpp" line="2727"/>
+        <location filename="../../src/grlida.cpp" line="2214"/>
+        <location filename="../../src/grlida.cpp" line="2749"/>
         <source>NÂº juegos</source>
         <translation>Количество игр</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1537"/>
+        <location filename="../../src/grlida.cpp" line="1549"/>
         <source>InformaciÃ³n no disponible</source>
         <translation>Information not available</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2683"/>
+        <location filename="../../src/grlida.cpp" line="2705"/>
         <source>introducido el</source>
         <translation>Добавлено в БД</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3216"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3238"/>
         <source>Si</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1606"/>
-        <location filename="../../src/grlida.cpp" line="2034"/>
+        <location filename="../../src/grlida.cpp" line="1618"/>
+        <location filename="../../src/grlida.cpp" line="2046"/>
         <source>SubtÃ­tulo</source>
         <translation>Подзаголовок</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1924"/>
+        <location filename="../../src/grlida.cpp" line="1936"/>
         <source>The file is not an XBEL version 1.0 file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Actualizaciones</source>
         <translation>Updates</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>No existen actualizaciones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Mostrar</source>
         <translation>Show</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="1933"/>
+        <location filename="../../src/grlida.cpp" line="1945"/>
         <source>Aceptar</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2042"/>
+        <location filename="../../src/grlida.cpp" line="2054"/>
         <source>Idioma Voces</source>
         <translation>Язык озвучки</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2045"/>
+        <location filename="../../src/grlida.cpp" line="2057"/>
         <source>NÂº Discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2053"/>
+        <location filename="../../src/grlida.cpp" line="2065"/>
         <source>Fecha</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="2632"/>
-        <location filename="../../src/grlida.cpp" line="2639"/>
-        <location filename="../../src/grlida.cpp" line="2641"/>
-        <location filename="../../src/grlida.cpp" line="3221"/>
+        <location filename="../../src/grlida.cpp" line="2649"/>
+        <location filename="../../src/grlida.cpp" line="2656"/>
+        <location filename="../../src/grlida.cpp" line="2658"/>
+        <location filename="../../src/grlida.cpp" line="3243"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3157"/>
+        <location filename="../../src/grlida.cpp" line="3179"/>
         <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3161"/>
+        <location filename="../../src/grlida.cpp" line="3183"/>
         <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3162"/>
+        <location filename="../../src/grlida.cpp" line="3184"/>
         <source>Ademas borrara lo marcado siempre y cuando este dentro del directorio del GR-lida.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3177"/>
+        <location filename="../../src/grlida.cpp" line="3199"/>
         <source>Eliminar carÃ¡tula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3181"/>
+        <location filename="../../src/grlida.cpp" line="3203"/>
         <source>Eliminar imÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3186"/>
+        <location filename="../../src/grlida.cpp" line="3208"/>
         <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3190"/>
+        <location filename="../../src/grlida.cpp" line="3212"/>
         <source>Eliminar capturas de pantalla.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3194"/>
+        <location filename="../../src/grlida.cpp" line="3216"/>
         <source>Eliminar imÃ¡genes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3198"/>
+        <location filename="../../src/grlida.cpp" line="3220"/>
         <source>Eliminar capturas de sonido.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3202"/>
+        <location filename="../../src/grlida.cpp" line="3224"/>
         <source>Eliminar capturas de video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3206"/>
+        <location filename="../../src/grlida.cpp" line="3228"/>
         <source>Eliminar archivos guardados.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3253"/>
+        <location filename="../../src/grlida.cpp" line="3275"/>
         <source>CarÃ¡tula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3260"/>
+        <location filename="../../src/grlida.cpp" line="3282"/>
         <source>ImÃ¡genes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3272"/>
+        <location filename="../../src/grlida.cpp" line="3294"/>
         <source>Capturas de pantalla</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3279"/>
+        <location filename="../../src/grlida.cpp" line="3301"/>
         <source>ImÃ¡genes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3287"/>
+        <location filename="../../src/grlida.cpp" line="3309"/>
         <source>Capturas de videos</source>
         <translation>Захваченное видео</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3313"/>
+        <location filename="../../src/grlida.cpp" line="3335"/>
         <source>ConfiguraciÃ³n de DOSBox</source>
         <translation>Конфигурация DOSBox</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3331"/>
+        <location filename="../../src/grlida.cpp" line="3353"/>
         <source>ConfiguraciÃ³n de ScummVM</source>
         <translation>Конфигурация ScummVM</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3339"/>
+        <location filename="../../src/grlida.cpp" line="3361"/>
         <source>ConfiguraciÃ³n de VDMSound</source>
         <translation>Конфигурация VDMSound</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>El juego ha sido eliminado correctamente</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3384"/>
+        <location filename="../../src/grlida.cpp" line="3406"/>
         <source>Ha borrado</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3505"/>
+        <location filename="../../src/grlida.cpp" line="3527"/>
         <source>Ejecutar</source>
         <translation>Запустить</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4816"/>
+        <location filename="../../src/grlida.cpp" line="4838"/>
         <source>Se ha producido un error al salir del proceso</source>
         <translation>There was an error out of the process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4841"/>
+        <location filename="../../src/grlida.cpp" line="4863"/>
         <source>Se ha producido un error al iniciar el proceso de inicio</source>
         <translation>There was an error starting the boot process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4844"/>
+        <location filename="../../src/grlida.cpp" line="4866"/>
         <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
         <translation>There was an error in the process, time after starting successfully</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4847"/>
+        <location filename="../../src/grlida.cpp" line="4869"/>
         <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
         <translation>There was an error, waitFor...() Last time out function</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4850"/>
+        <location filename="../../src/grlida.cpp" line="4872"/>
         <source>Se ha producido un error al intentar escribir en el proceso de inicio</source>
         <translation>There was an error while trying to write to the boot process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4853"/>
+        <location filename="../../src/grlida.cpp" line="4875"/>
         <source>Se ha producido un error al intentar leer en el proceso</source>
         <translation>There was an error while trying to read in the process</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="4856"/>
+        <location filename="../../src/grlida.cpp" line="4878"/>
         <source>Ha ocurrido un error desconocido</source>
         <translation>There was an unknown error</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3127"/>
-        <location filename="../../src/grlida.cpp" line="3388"/>
+        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3410"/>
         <source>Por favor selecciona un juego de la lista para eliminarlo</source>
         <translation>Пожалуйста, выберите игру из списка для удаления</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3149"/>
+        <location filename="../../src/grlida.cpp" line="3171"/>
         <source>Â¿Eliminar juego...?</source>
         <translation>Удаление иры...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida.cpp" line="3014"/>
+        <location filename="../../src/grlida.cpp" line="3036"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>Запускаемый файл эмулятора не найден.
@@ -2588,37 +2588,37 @@ Please check the media service plugins are installed.</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="825"/>
+        <location filename="../../src/dbsql.cpp" line="859"/>
         <source>Generos</source>
         <translation>Жанр</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="826"/>
+        <location filename="../../src/dbsql.cpp" line="860"/>
         <source>Temas</source>
         <translation>Тема</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="827"/>
+        <location filename="../../src/dbsql.cpp" line="861"/>
         <source>Desarrolladores</source>
         <translation>Разработчики</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="828"/>
+        <location filename="../../src/dbsql.cpp" line="862"/>
         <source>CompaÃ±ias</source>
         <translation>Компании</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="829"/>
+        <location filename="../../src/dbsql.cpp" line="863"/>
         <source>AÃ±os</source>
         <translation>Год</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="830"/>
+        <location filename="../../src/dbsql.cpp" line="864"/>
         <source>Idiomas</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location filename="../../src/dbsql.cpp" line="849"/>
+        <location filename="../../src/dbsql.cpp" line="883"/>
         <source>Todos</source>
         <translation>Все</translation>
     </message>
@@ -2748,11 +2748,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Selecciona un archivo</source>
         <translation>Выберите файл</translation>
     </message>
@@ -2765,11 +2765,11 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="840"/>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="865"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1257"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1251"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Todos los archivos</source>
         <translation>Все файлы</translation>
     </message>
@@ -2794,19 +2794,19 @@ Please check the media service plugins are installed.</source>
         <translation>Вы действительно хотите удалить это монтирование?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1215"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1222"/>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1229"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1209"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1216"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1223"/>
         <source>Seleccionar un directorio</source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1277"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1271"/>
         <source>Idioma</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1236"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1230"/>
         <source>Imagen</source>
         <translation>Картинка</translation>
     </message>
@@ -2816,12 +2816,12 @@ Please check the media service plugins are installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1243"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1237"/>
         <source>Imagen CD</source>
         <translation>Картинка CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1250"/>
+        <location filename="../../src/grlida_addedit_dosbox.cpp" line="1244"/>
         <source>Imagen HD</source>
         <translation>Картинка HD</translation>
     </message>
@@ -4358,121 +4358,130 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="64"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>Образ ISO, CUE+BIN</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="65"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
         <source>Imagen ISO multiples</source>
         <translation>Несколько образов ISO</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="66"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
         <source>Imagen de disco duro</source>
         <translation>Образ жесткого диска</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="67"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="68"/>
         <source>Imagen Botable</source>
         <translation>Загрузочный образ</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="70"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <source>No usar nada</source>
         <translation>Не использовать ничего</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Usar</source>
         <translation>Использовать</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="71"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
         <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
         <translation>Force ASPI layer usage. Only Windows with ASPI-Layer</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
         <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
         <translation>Automatic Audio CD interface</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
         <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio extraction for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
         <source>Llamadas ioctl utiliza para CD de audio</source>
         <translation>IOCTL calls for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="75"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
         <source>MCI utiliza para CD de audio</source>
         <translation>Use MCI for Audio CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="76"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
         <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
         <translation>Force SDL for CD-ROM. Available in all systems</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="87"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="88"/>
         <source>NO usar CD</source>
         <translation>Не монтировать CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="272"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="273"/>
         <source>Seleccionar un directorio</source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Todos los archivos</source>
         <translation>Все файлы</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
         <source>Â¿Eliminar...?</source>
         <translation>Удалить...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="347"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>В действительно хотите удалить образ ISO из списка?</translation>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="397"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">В действительно хотите удалить образ ISO из списка?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="398"/>
         <source>Espacio libre virtual (%1 %2)</source>
         <translation>Virtual free space (%1 %2)</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>Procura no montar la Raiz del sistema operativo: ejemplo en windows seria</source>
         <translation>Пытаться не включать путь вашей системы при монтировании: например,</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="120"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="121"/>
         <source>y en linux seria directamente</source>
         <translation>это может быть допустимо под Windows и под Linux</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="281"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="282"/>
         <source>Imagen</source>
         <translation>Картинка</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="283"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="284"/>
         <source>Imagen CD</source>
         <translation>Картинка CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_addedit_montajes.cpp" line="287"/>
+        <location filename="../../src/grlida_addedit_montajes.cpp" line="288"/>
         <source>Selecciona un archivo</source>
         <translation>Выберите файл</translation>
     </message>
@@ -6670,69 +6679,78 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="86"/>
+        <source>Imagen de disquete multiples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
         <source>Imagen ISO, CUE/BIN</source>
         <translation>Образ ISO, CUE+BIN</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="87"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
         <source>Imagen ISO multiples</source>
         <translation>Несколько образов ISO</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="88"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="89"/>
         <source>Imagen de disco duro</source>
         <translation>Образ жесткого диска</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="168"/>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="252"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="169"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="253"/>
         <source>Seleccionar un directorio</source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Todos los archivos</source>
         <translation>Все файлы</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
         <source>Â¿Eliminar...?</source>
         <translation>Удалить...?</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="243"/>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
-        <translation>В действительно хотите удалить образ ISO из списка?</translation>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="244"/>
+        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="282"/>
+        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <translation type="obsolete">В действительно хотите удалить образ ISO из списка?</translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="283"/>
         <source>El ejecutable suele ser: INSTALL, si no esta seguro teclee DIR y pulsa INTRO</source>
         <translation>Эта программа, обычно, называется INSTALL. Если вы не уверены, наберите DIR и нажмите ENTER</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="347"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="355"/>
         <source>Puede que no este disponible el ejecutable del emulador.
 O el directorio de destino.</source>
         <translation>Либо запускаемый файл программы отсутствует, 
 либо неправильно указана папка.</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="177"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="178"/>
         <source>Imagen</source>
         <translation>Картинка</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="179"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="180"/>
         <source>Imagen CD</source>
         <translation>Картинка CD</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="183"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="184"/>
         <source>Selecciona un archivo</source>
         <translation>Выберите файл</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_instalar_juego.cpp" line="131"/>
+        <location filename="../../src/grlida_instalar_juego.cpp" line="132"/>
         <source>No esta disponible el ejecutable del emulador.
 Compruebe si lo tiene instalado.</source>
         <translation>Запускаемый файл эмулятора не найден.
@@ -7483,6 +7501,7 @@ Compruebe si lo tiene instalado.</source>
         <translation>Метка</translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="2440"/>
         <location filename="../../src/grlida_opciones.cpp" line="2490"/>
         <location filename="../../src/grlida_opciones.cpp" line="2508"/>
         <source>Config</source>
@@ -7800,6 +7819,51 @@ Compruebe si lo tiene instalado.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/grlida_opciones.cpp" line="174"/>
+        <source>Cada veinticuatro horas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="175"/>
+        <source>Semanalmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="176"/>
+        <source>Mensualmente</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="202"/>
+        <location filename="../../src/grlida_opciones.cpp" line="246"/>
+        <location filename="../../src/grlida_opciones.cpp" line="283"/>
+        <location filename="../../src/grlida_opciones.cpp" line="316"/>
+        <location filename="../../src/grlida_opciones.cpp" line="342"/>
+        <location filename="../../src/grlida_opciones.cpp" line="391"/>
+        <location filename="../../src/grlida_opciones.cpp" line="498"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2427"/>
+        <source>ImÃ¡genes CategorÃ­as</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="249"/>
+        <location filename="../../src/grlida_opciones.cpp" line="286"/>
+        <location filename="../../src/grlida_opciones.cpp" line="319"/>
+        <location filename="../../src/grlida_opciones.cpp" line="345"/>
+        <location filename="../../src/grlida_opciones.cpp" line="394"/>
+        <location filename="../../src/grlida_opciones.cpp" line="501"/>
+        <location filename="../../src/grlida_opciones.cpp" line="2429"/>
+        <source>ImÃ¡genes defecto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="322"/>
+        <location filename="../../src/grlida_opciones.cpp" line="348"/>
+        <location filename="../../src/grlida_opciones.cpp" line="504"/>
+        <source>ImÃ¡genes idiomas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/grlida_opciones.cpp" line="555"/>
         <source>Thumb en JPG</source>
         <translation type="unfinished"></translation>
@@ -7957,6 +8021,13 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2836"/>
         <source>Color de texto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/grlida_opciones.cpp" line="3075"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3105"/>
+        <location filename="../../src/grlida_opciones.cpp" line="3135"/>
+        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8917,7 +8988,7 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../ui/update.ui" line="20"/>
         <location filename="../../ui/update.ui" line="64"/>
-        <location filename="../../src/grlida_update.cpp" line="108"/>
+        <location filename="../../src/grlida_update.cpp" line="121"/>
         <source>Actualizaciones</source>
         <translation>Updates</translation>
     </message>
@@ -8942,27 +9013,27 @@ Compruebe si lo tiene instalado.</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="64"/>
+        <location filename="../../src/grlida_update.cpp" line="74"/>
         <source>Estilos o themes para el GR-lida</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Descargar</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="130"/>
+        <location filename="../../src/grlida_update.cpp" line="143"/>
         <source>Actualizar</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="70"/>
+        <location filename="../../src/grlida_update.cpp" line="82"/>
         <source>Lista de compatibilidad del ScummVM</source>
         <translation>ScummVM compatibility list</translation>
     </message>
     <message>
-        <location filename="../../src/grlida_update.cpp" line="58"/>
+        <location filename="../../src/grlida_update.cpp" line="65"/>
         <source>Script para importar datos del juego</source>
         <translation>Script to import game data</translation>
     </message>

--- a/src/grlida_opciones.cpp
+++ b/src/grlida_opciones.cpp
@@ -171,9 +171,9 @@ void frmOpciones::cargarConfig()
 
 // Actualizaciones -------------------
 	ui->cbxUpdateInterval->clear();
-	ui->cbxUpdateInterval->addItem(QIcon(fGrl->theme() +"img16/fecha.png"), "Cada veinticuatro horas",  1);
-	ui->cbxUpdateInterval->addItem(QIcon(fGrl->theme() +"img16/fecha.png"), "Semanalmente",  7);
-	ui->cbxUpdateInterval->addItem(QIcon(fGrl->theme() +"img16/fecha.png"), "Mensualmente", 30);
+	ui->cbxUpdateInterval->addItem(QIcon(fGrl->theme() +"img16/fecha.png"), tr("Cada veinticuatro horas"),  1);
+	ui->cbxUpdateInterval->addItem(QIcon(fGrl->theme() +"img16/fecha.png"), tr("Semanalmente"),  7);
+	ui->cbxUpdateInterval->addItem(QIcon(fGrl->theme() +"img16/fecha.png"), tr("Mensualmente"), 30);
 
 	int idx_update_interval = ui->cbxUpdateInterval->findData(grlCfg.chkUpdateInterval, Qt::UserRole, Qt::MatchExactly);
 	ui->cbxUpdateInterval->setCurrentIndex(idx_update_interval);
@@ -199,7 +199,7 @@ void frmOpciones::cargarConfig()
 	ui->cbxDbxVersion->setCurrentIndex(0);
 
 	ui->cbxDbxImg->clear();
-	ui->cbxDbxImg->addItemParent("Imágenes Categorías");
+	ui->cbxDbxImg->addItemParent(tr("Imágenes Categorías"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxDbxImg, fGrl->theme(), "img32/cat/", "cat/", grlCfg.FormatsImage.join(";"));
 
 	emit on_btnDbxCancel_clicked();
@@ -243,10 +243,10 @@ void frmOpciones::cargarConfig()
 	ui->txtEmuDato->setValidator(new QRegExpValidator(regexp, ui->txtEmuDato));
 
 	ui->cbxEmuImg->clear();
-	ui->cbxEmuImg->addItemParent("Imágenes Categorías");
+	ui->cbxEmuImg->addItemParent(tr("Imágenes Categorías"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxEmuImg, fGrl->theme(), "img32/cat/", "cat/", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxEmuImg->addItemParent("Imágenes defecto");
+	ui->cbxEmuImg->addItemParent(tr("Imágenes defecto"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxEmuImg, fGrl->theme(), "img32/", "", grlCfg.FormatsImage.join(";"));
 
 	int row = ui->cbxEmuImg->findData("sinimg.png", Qt::UserRole, Qt::MatchContains);
@@ -280,10 +280,10 @@ void frmOpciones::cargarConfig()
 	ui->txtCatTabla->setValidator(new QRegExpValidator(regexp, ui->txtCatTabla));
 
 	ui->cbxCatImg->clear();
-	ui->cbxCatImg->addItemParent("Imágenes Categorías");
+	ui->cbxCatImg->addItemParent(tr("Imágenes Categorías"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxCatImg, fGrl->theme(), "img32/cat/", "cat/", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxCatImg->addItemParent("Imágenes defecto");
+	ui->cbxCatImg->addItemParent(tr("Imágenes defecto"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxCatImg, fGrl->theme(), "img32/", "", grlCfg.FormatsImage.join(";"));
 
 	row = ui->cbxCatImg->findData("sinimg.png", Qt::UserRole, Qt::MatchContains);
@@ -313,13 +313,13 @@ void frmOpciones::cargarConfig()
 
 // Crear, editar menú nav ------------
 	ui->cbxMnuNavImg->clear();
-	ui->cbxMnuNavImg->addItemParent("Imágenes Categorías");
+	ui->cbxMnuNavImg->addItemParent(tr("Imágenes Categorías"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxMnuNavImg, fGrl->theme(), "img16/cat/", "cat/", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxMnuNavImg->addItemParent("Imágenes defecto");
+	ui->cbxMnuNavImg->addItemParent(tr("Imágenes defecto"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxMnuNavImg, fGrl->theme(), "img16/", "", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxMnuNavImg->addItemParent("Imágenes idiomas");
+	ui->cbxMnuNavImg->addItemParent(tr("Imágenes idiomas"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxMnuNavImg, fGrl->theme(), "img16/lng/", "lng/", grlCfg.FormatsImage.join(";"));
 
 	row = ui->cbxMnuNavImg->findData("sinimg.png", Qt::UserRole, Qt::MatchContains);
@@ -339,13 +339,13 @@ void frmOpciones::cargarConfig()
 // Crear, editar menú shortcut -------
 	ui->cbxMnuShortCutImg->setIconSize(QSize(32, 32));
 	ui->cbxMnuShortCutImg->clear();
-	ui->cbxMnuShortCutImg->addItemParent("Imágenes Categorías");
+	ui->cbxMnuShortCutImg->addItemParent(tr("Imágenes Categorías"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxMnuShortCutImg, fGrl->theme(), "img32/cat/", "cat/", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxMnuShortCutImg->addItemParent("Imágenes defecto");
+	ui->cbxMnuShortCutImg->addItemParent(tr("Imágenes defecto"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxMnuShortCutImg, fGrl->theme(), "img32/", "", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxMnuShortCutImg->addItemParent("Imágenes idiomas");
+	ui->cbxMnuShortCutImg->addItemParent(tr("Imágenes idiomas"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxMnuShortCutImg, fGrl->theme(), "img32/lng/", "lng/", grlCfg.FormatsImage.join(";"));
 
 	row = ui->cbxMnuShortCutImg->findData("sinimg.png", Qt::UserRole, Qt::MatchContains);
@@ -388,10 +388,10 @@ void frmOpciones::cargarConfig()
 	fGrl->cargarIconosComboBox(ui->cbxDatImgCmpt, fGrl->theme(), "img_svm/level/", "", "sinimg.png", grlCfg.FormatsImage.join(";"));
 
 	ui->cbxDatImg->clear();
-	ui->cbxDatImg->addItemParent("Imágenes Categorías");
+	ui->cbxDatImg->addItemParent(tr("Imágenes Categorías"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxDatImg, fGrl->theme(), "img16/cat/", "cat/", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxDatImg->addItemParent("Imágenes defecto");
+	ui->cbxDatImg->addItemParent(tr("Imágenes defecto"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxDatImg, fGrl->theme(), "img16/", "", grlCfg.FormatsImage.join(";"));
 
 	row = ui->cbxDatImg->findData("sinimg.png", Qt::UserRole, Qt::MatchContains);
@@ -495,13 +495,13 @@ void frmOpciones::cargarConfig()
 
 	ui->cbxPicFlowIconExtraImage->clear();
 	ui->cbxPicFlowIconExtraImage->setIconSize(QSize(32, 32));
-	ui->cbxPicFlowIconExtraImage->addItemParent("Imágenes Categorías");
+	ui->cbxPicFlowIconExtraImage->addItemParent(tr("Imágenes Categorías"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxPicFlowIconExtraImage, fGrl->theme(), "img32/cat/", "cat/", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxPicFlowIconExtraImage->addItemParent("Imágenes defecto");
+	ui->cbxPicFlowIconExtraImage->addItemParent(tr("Imágenes defecto"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxPicFlowIconExtraImage, fGrl->theme(), "img32/", "", grlCfg.FormatsImage.join(";"));
 
-	ui->cbxPicFlowIconExtraImage->addItemParent("Imágenes idiomas");
+	ui->cbxPicFlowIconExtraImage->addItemParent(tr("Imágenes idiomas"));
 	fGrl->cargarIconosGroupComboBox(ui->cbxPicFlowIconExtraImage, fGrl->theme(), "img32/lng/", "lng/", grlCfg.FormatsImage.join(";"));
 
 	ui->cbxPicFlowIconExtraUse->clear();
@@ -2424,9 +2424,9 @@ void frmOpciones::on_cbxDatArchivo_activated(int index)
 		isLng = true;
 		fGrl->cargarIconosComboBox(ui->cbxDatImg, fGrl->theme(), "img16/lng/", "lng/", "sinimg.png", grlCfg.FormatsImage.join(";"));
 	} else {
-		ui->cbxDatImg->addItemParent("Imágenes Categorías");
+		ui->cbxDatImg->addItemParent(tr("Imágenes Categorías"));
 		fGrl->cargarIconosGroupComboBox(ui->cbxDatImg, fGrl->theme(), "img16/cat/", "cat/", grlCfg.FormatsImage.join(";"));
-		ui->cbxDatImg->addItemParent("Imágenes defecto");
+		ui->cbxDatImg->addItemParent(tr("Imágenes defecto"));
 		fGrl->cargarIconosGroupComboBox(ui->cbxDatImg, fGrl->theme(), "img16/", "", grlCfg.FormatsImage.join(";"));
 	}
 	int row = ui->cbxDatImg->findData("sinimg.png", Qt::UserRole, Qt::MatchContains);
@@ -2437,7 +2437,7 @@ void frmOpciones::on_cbxDatArchivo_activated(int index)
 	ui->twDatos->headerItem()->setIcon(2, QIcon(fGrl->theme() +"img16/bullet_black.png"));
 	ui->twDatos->headerItem()->setIcon(3, QIcon(fGrl->theme() +"img16/bullet_black.png"));
 	ui->twDatos->headerItem()->setText(0, tr("Título"));
-	ui->twDatos->headerItem()->setText(1, "Config");
+	ui->twDatos->headerItem()->setText(1, tr("Config"));
 	ui->twDatos->headerItem()->setText(2, "");
 	ui->twDatos->headerItem()->setText(3, "");
 	ui->twDatos->headerItem()->setTextAlignment(1, Qt::AlignCenter);
@@ -3072,7 +3072,7 @@ void frmOpciones::on_btnExtVideoDelete_clicked()
 {
 	if (ui->lwExtVideo->count() > 0 && ui->lwExtVideo->currentItem()->isSelected())
 	{
-		if (fGrl->questionMsg(tr("¿Eliminar...?"), "¿Deseas eliminar la extensión?"))
+		if (fGrl->questionMsg(tr("¿Eliminar...?"), tr("¿Deseas eliminar la extensión?")))
 			delete ui->lwExtVideo->currentItem();
 	}
 }
@@ -3102,7 +3102,7 @@ void frmOpciones::on_btnExtMusicDelete_clicked()
 {
 	if (ui->lwExtMusic->count() > 0 && ui->lwExtMusic->currentItem()->isSelected())
 	{
-		if (fGrl->questionMsg(tr("¿Eliminar...?"), "¿Deseas eliminar la extensión?"))
+		if (fGrl->questionMsg(tr("¿Eliminar...?"), tr("¿Deseas eliminar la extensión?")))
 			delete ui->lwExtMusic->currentItem();
 	}
 }
@@ -3132,7 +3132,7 @@ void frmOpciones::on_btnExtImageDelete_clicked()
 {
 	if (ui->lwExtImage->count() > 0 && ui->lwExtImage->currentItem()->isSelected())
 	{
-		if (fGrl->questionMsg(tr("¿Eliminar...?"), "¿Deseas eliminar la extensión?"))
+		if (fGrl->questionMsg(tr("¿Eliminar...?"), tr("¿Deseas eliminar la extensión?")))
 			delete ui->lwExtImage->currentItem();
 	}
 }


### PR DESCRIPTION
Some strings weren't declared as translatable with `tr()`, so I've fixed this. I've also changed some translation which were inaccurate or simply wrong (most prominent: _to_ instead of _of_ in range indicators, like _Game: 5 of 6_ in the lower left of the main window).