### PR TITLE
Use UTF-8 for .ts files

### DIFF
--- a/gr-lida.pro
+++ b/gr-lida.pro
@@ -193,7 +193,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 #CODECFORTR  = UTF-8
-#CODECFORSRC = UTF-8
+CODECFORSRC = UTF-8
 
 TRANSLATIONS += res/idiomas/gr-lida_es_ES.ts \
     res/idiomas/gr-lida_en_EN.ts \

--- a/res/idiomas/gr-lida_da_DK.ts
+++ b/res/idiomas/gr-lida_da_DK.ts
@@ -101,32 +101,32 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="359"/>
-        <source>SuperÃ­ndice</source>
+        <source>Superíndice</source>
         <translation>hævet</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="362"/>
-        <source>SubÃ­ndice</source>
+        <source>Subíndice</source>
         <translation>sænket</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="396"/>
-        <source>CÃ³digo</source>
+        <source>Código</source>
         <translation>kode</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="433"/>
-        <source>Coincidir mayÃºsculas/minÃºsculas</source>
+        <source>Coincidir mayúsculas/minúsculas</source>
         <translation>Match store / små bogstaver</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1125"/>
-        <source>ImÃ¡genes</source>
+        <source>Imágenes</source>
         <translation>Billede</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1130"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Understøttede billeder</translation>
     </message>
     <message>
@@ -242,12 +242,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿Sobrescribir?</source>
+        <source>¿Sobrescribir?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿El archivo &apos;</source>
+        <source>¿El archivo &apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -257,7 +257,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1004"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Front cover</translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1006"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Karakter</translation>
     </message>
     <message>
@@ -282,7 +282,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1009"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Titel</translation>
     </message>
     <message>
@@ -362,12 +362,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1024"/>
-        <source>AÃ±adido el</source>
+        <source>Añadido el</source>
         <translation>Tilføjet</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1025"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafik</translation>
     </message>
     <message>
@@ -397,7 +397,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1031"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Beskrivelse</translation>
     </message>
     <message>
@@ -407,17 +407,17 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1033"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1037"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titel</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1038"/>
-        <source>TÃ­tulo album</source>
+        <source>Título album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -427,7 +427,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="2041"/>
-        <source>ConfiguraciÃ³n por defecto</source>
+        <source>Configuración por defecto</source>
         <translation>Standardkonfiguration</translation>
     </message>
     <message>
@@ -792,43 +792,43 @@
         <location filename="../../src/grdap.cpp" line="874"/>
         <location filename="../../src/grdap.cpp" line="880"/>
         <location filename="../../src/grdap.cpp" line="949"/>
-        <source>Âº</source>
+        <source>º</source>
         <translation>º</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="443"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Størrelse</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="495"/>
         <location filename="../../src/grdap.cpp" line="530"/>
-        <source>Seleccione la configuraciÃ³n que quieres abrir.</source>
+        <source>Seleccione la configuración que quieres abrir.</source>
         <translation>Vælg den indstilling, du vil åbne.</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="587"/>
-        <source>TÃ­tulo del juego</source>
+        <source>Título del juego</source>
         <translation>Spil titel</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="590"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Beskrivelse</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="725"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Side</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="799"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Kopibeskyttelsessignal billede</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="800"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Understøttede billeder</translation>
     </message>
     <message>
@@ -2027,8 +2027,8 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="376"/>
-        <source>No se ha podido establecer una conexiÃ³n con la base de datos.
-Esta aplicaciÃ³n necesita soporte de SQLite. Mira la documentaciÃ³n de Qt SQL driver para mÃ¡s informaciÃ³n.
+        <source>No se ha podido establecer una conexión con la base de datos.
+Esta aplicación necesita soporte de SQLite. Mira la documentación de Qt SQL driver para más información.
 
 Click cancelar para salir.</source>
         <translation>Kunne ikke forbinde til database.
@@ -2039,30 +2039,30 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1653"/>
         <location filename="../../src/grlida.cpp" line="2094"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titel</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1656"/>
         <location filename="../../src/grlida.cpp" line="2097"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Udgiver</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1661"/>
         <location filename="../../src/grlida.cpp" line="2105"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>År</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1662"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1664"/>
         <location filename="../../src/grlida.cpp" line="2109"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafik</translation>
     </message>
     <message>
@@ -2072,7 +2072,7 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2108"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Størrelse</translation>
     </message>
     <message>
@@ -2084,12 +2084,12 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="2263"/>
         <location filename="../../src/grlida.cpp" line="2825"/>
-        <source>NÂº juegos</source>
+        <source>Nº juegos</source>
         <translation>Antal spil</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1584"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information er ikke tilgængelig</translation>
     </message>
     <message>
@@ -2108,7 +2108,7 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1654"/>
         <location filename="../../src/grlida.cpp" line="2095"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Titel</translation>
     </message>
     <message>
@@ -2143,7 +2143,7 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2106"/>
-        <source>NÂº Discos</source>
+        <source>Nº Discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
@@ -2166,12 +2166,12 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3321"/>
-        <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3325"/>
-        <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
+        <source>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2181,17 +2181,17 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3341"/>
-        <source>Eliminar carÃ¡tula thumbs.</source>
+        <source>Eliminar carátula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3345"/>
-        <source>Eliminar imÃ¡genes de la caja.</source>
+        <source>Eliminar imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3350"/>
-        <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
+        <source>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2201,7 +2201,7 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3358"/>
-        <source>Eliminar imÃ¡genes.</source>
+        <source>Eliminar imágenes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2221,12 +2221,12 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3417"/>
-        <source>CarÃ¡tula</source>
+        <source>Carátula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3424"/>
-        <source>ImÃ¡genes de la caja.</source>
+        <source>Imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2236,7 +2236,7 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3443"/>
-        <source>ImÃ¡genes del juego</source>
+        <source>Imágenes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2246,17 +2246,17 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3477"/>
-        <source>ConfiguraciÃ³n de DOSBox</source>
+        <source>Configuración de DOSBox</source>
         <translation>konfiguration DOSBox</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3495"/>
-        <source>ConfiguraciÃ³n de ScummVM</source>
+        <source>Configuración de ScummVM</source>
         <translation>konfiguration ScummVM</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3503"/>
-        <source>ConfiguraciÃ³n de VDMSound</source>
+        <source>Configuración de VDMSound</source>
         <translation>konfiguration VDMSound</translation>
     </message>
     <message>
@@ -2292,12 +2292,12 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5112"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>Der opstod en fejl i processen, tid efter start med succes</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5115"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>Der opstod en fejl, vent ... () Sidste gang out funktion</translation>
     </message>
     <message>
@@ -2323,7 +2323,7 @@ Klik på &apos;Annuller&apos; for at afslutte.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3313"/>
-        <source>Â¿Eliminar juego...?</source>
+        <source>¿Eliminar juego...?</source>
         <translation>Slet spil...?</translation>
     </message>
     <message>
@@ -2441,7 +2441,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="319"/>
-        <source>Â¿Redireccionar a &apos;%1&apos;?</source>
+        <source>¿Redireccionar a &apos;%1&apos;?</source>
         <translation>Omdirigere til %1?</translation>
     </message>
     <message>
@@ -2466,7 +2466,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="402"/>
-        <source>Uno o mÃ¡s errores de SSL se ha producido: %1</source>
+        <source>Uno o más errores de SSL se ha producido: %1</source>
         <translation>En eller flere SSL mapper er sket: %1</translation>
     </message>
     <message>
@@ -2533,7 +2533,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="46"/>
-        <source>Cargando configuraciÃ³n...</source>
+        <source>Cargando configuración...</source>
         <translation>Loading konfiguration...</translation>
     </message>
     <message>
@@ -2661,12 +2661,12 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="882"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Udgiver</translation>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="883"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>År</translation>
     </message>
     <message>
@@ -2684,12 +2684,12 @@ Please check the media service plugins are installed.</source>
     <name>frmAcercaD</name>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="68"/>
-        <source>es un lanzador comÃºn para los emuladores:</source>
+        <source>es un lanzador común para los emuladores:</source>
         <translation>er en fælles løfteraket til de programmer:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="70"/>
-        <source>es GPL. Para mejorar el programa puedes dejar tu opiniÃ³n en</source>
+        <source>es GPL. Para mejorar el programa puedes dejar tu opinión en</source>
         <translation>det er GPL. En konstruktiv kritik er velkommen på</translation>
     </message>
     <message>
@@ -2832,22 +2832,22 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Slet montering indstillinger?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Ønsker du at slette denne montering?</translation>
     </message>
     <message>
@@ -4243,7 +4243,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="385"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2584"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Kopibeskyttelsessignal billede</translation>
     </message>
     <message>
@@ -4253,32 +4253,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="390"/>
-        <source>CarÃ¡tula delantera</source>
+        <source>Carátula delantera</source>
         <translation>Forsideomslag</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="391"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Bagdæksel</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="392"/>
-        <source>CarÃ¡tula izquierda</source>
+        <source>Carátula izquierda</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="393"/>
-        <source>CarÃ¡tula derecha</source>
+        <source>Carátula derecha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="394"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="395"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4288,7 +4288,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="441"/>
-        <source>AÃ±adiendo un nuevo juego</source>
+        <source>Añadiendo un nuevo juego</source>
         <translation>Tilføjelse af et nyt spil</translation>
     </message>
     <message>
@@ -4325,7 +4325,7 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1725"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1783"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1874"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Understøttede billeder</translation>
     </message>
     <message>
@@ -4356,17 +4356,17 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Slet...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1795"/>
-        <source>Â¿Deseas eliminar la imagen seleccionada?</source>
+        <source>¿Deseas eliminar la imagen seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
-        <source>Â¿Deseas eliminar la captura seleccionada?</source>
+        <source>¿Deseas eliminar la captura seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4376,7 +4376,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
-        <source>Â¿Deseas eliminar el video seleccionado?</source>
+        <source>¿Deseas eliminar el video seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4386,7 +4386,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Deseas eliminar el sonido seleccionado?</source>
+        <source>¿Deseas eliminar el sonido seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4400,7 +4400,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2096"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2194"/>
-        <source>Para aÃ±adir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
+        <source>Para añadir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4426,32 +4426,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Eliminar url...?</source>
+        <source>¿Eliminar url...?</source>
         <translation>Slet adresse?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Deseas eliminar esta url?</source>
+        <source>¿Deseas eliminar esta url?</source>
         <translation>Ønsker du at slette denne URL?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Eliminar archivo...?</source>
+        <source>¿Eliminar archivo...?</source>
         <translation>Slet filen...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Deseas eliminar este archivo?</source>
+        <source>¿Deseas eliminar este archivo?</source>
         <translation>Vil du virkelig slette denne fil?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="86"/>
-        <source>Â¿Cerrar ventana?</source>
+        <source>¿Cerrar ventana?</source>
         <translation>Luk vinduet?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="87"/>
-        <source>Â¿Deseas realmente cerrar la ventana?
+        <source>¿Deseas realmente cerrar la ventana?
 Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios efectuados.</source>
         <translation>Vil du virkelig lukke dette vindue?
 Ikke gemte data eller ændringer vil gå tabt.</translation>
@@ -4463,7 +4463,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1420"/>
-        <source>AÃ±adir grupo</source>
+        <source>Añadir grupo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4473,7 +4473,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1455"/>
-        <source>AÃ±adir</source>
+        <source>Añadir</source>
         <translation>Tilføj</translation>
     </message>
     <message>
@@ -4547,17 +4547,17 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
-        <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
+        <source>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</source>
         <translation>Kraft ASPI layer brug. Kun Windows med ASPI-Layer</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
-        <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
+        <source>Selección automática de la interfaz de audio de CD</source>
         <translation>Automatisk Audio CD-interface</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
-        <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
+        <source>Extracción digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio udtræk til Audio CD</translation>
     </message>
     <message>
@@ -4572,7 +4572,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
-        <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
+        <source>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</source>
         <translation>Kraft SDL for CD-ROM. Fås i alle systemer</translation>
     </message>
     <message>
@@ -4592,16 +4592,16 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Slet...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">Ønsker du at fjerne ISO fra listen?</translation>
     </message>
     <message>
@@ -5306,7 +5306,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="236"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation type="unfinished">Du skal sætte en titel.</translation>
     </message>
     <message>
@@ -5352,12 +5352,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="361"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="390"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Beskrivelse</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="386"/>
-        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuraciÃ³n.</source>
+        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5388,17 +5388,17 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="434"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="437"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation type="unfinished">Slet...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation type="unfinished">Vil du virkelig ønsker at slette denne emulator fra listen?</translation>
     </message>
     <message>
@@ -5490,12 +5490,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="60"/>
-        <source>A la categorÃ­a</source>
+        <source>A la categoría</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="66"/>
-        <source>Selecciona la categorÃ­a de destino</source>
+        <source>Selecciona la categoría de destino</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5559,7 +5559,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_compatibilidad_exe.cpp" line="232"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
@@ -5661,7 +5661,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="61"/>
-        <source>DiseÃ±ado y programado por</source>
+        <source>Diseñado y programado por</source>
         <translation>Designet og programed af</translation>
     </message>
     <message>
@@ -5686,7 +5686,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="62"/>
-        <source>Texto oculto en el manual del tipo Indiana Jones y la Ãltima Cruzada</source>
+        <source>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</source>
         <translation>Skjult tekst i manualen Indiana Jones and the Last Crusade</translation>
     </message>
 </context>
@@ -5719,12 +5719,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="76"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titel</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="80"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Titel</translation>
     </message>
     <message>
@@ -5779,7 +5779,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="145"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
@@ -5789,12 +5789,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="157"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Størrelse</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="162"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafik</translation>
     </message>
     <message>
@@ -5838,32 +5838,32 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="187"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Front cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="192"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Bagdæksel</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="197"/>
-        <source>CarÃ¡tula lateral izquierdo</source>
+        <source>Carátula lateral izquierdo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="202"/>
-        <source>CarÃ¡tula lateral derecho</source>
+        <source>Carátula lateral derecho</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="207"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="212"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5893,7 +5893,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="239"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Beskrivelse</translation>
     </message>
     <message>
@@ -6535,7 +6535,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_dosbox.cpp" line="660"/>
-        <source>Config - DespuÃ©s del exe</source>
+        <source>Config - Después del exe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6603,13 +6603,13 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <name>frmImportarJuego</name>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="164"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Information</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="192"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1432"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Side</translation>
     </message>
     <message>
@@ -6631,12 +6631,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="260"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation type="unfinished">Titel</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="261"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation type="unfinished">År</translation>
     </message>
     <message>
@@ -6647,12 +6647,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="293"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="308"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Beskrivelse</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="294"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation type="unfinished">Størrelse</translation>
     </message>
     <message>
@@ -6669,7 +6669,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="420"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="779"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information er ikke tilgængelig</translation>
     </message>
     <message>
@@ -6739,13 +6739,13 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="1851"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1872"/>
-        <source>AÃ±adiendo a la lista</source>
+        <source>Añadiendo a la lista</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="2776"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="2780"/>
-        <source>Importando imÃ¡genes, juego</source>
+        <source>Importando imágenes, juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7072,7 +7072,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="71"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Beskrivelse</translation>
     </message>
     <message>
@@ -7107,7 +7107,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="101"/>
-        <source>Modo grÃ¡fico:</source>
+        <source>Modo gráfico:</source>
         <translation>Grapic mode:</translation>
     </message>
     <message>
@@ -7162,12 +7162,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="148"/>
-        <source>Mostras subtÃ­tulo</source>
+        <source>Mostras subtítulo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="218"/>
-        <source>Velocidad de subtÃ­tulos:</source>
+        <source>Velocidad de subtítulos:</source>
         <translation>Vurder undertitel:</translation>
     </message>
     <message>
@@ -7177,12 +7177,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="154"/>
-        <source>Filtro de grÃ¡ficos</source>
+        <source>Filtro de gráficos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="157"/>
-        <source>CorrecciÃ³n de aspecto</source>
+        <source>Corrección de aspecto</source>
         <translation>Aspect korrektion</translation>
     </message>
     <message>
@@ -7237,7 +7237,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="206"/>
-        <source>Volumen mÃºsica:</source>
+        <source>Volumen música:</source>
         <translation>Musik volume:</translation>
     </message>
     <message>
@@ -7252,7 +7252,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="215"/>
-        <source>Tiempo de la mÃºsica:</source>
+        <source>Tiempo de la música:</source>
         <translation>Musik tempo:</translation>
     </message>
     <message>
@@ -7301,7 +7301,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <message>
         <location filename="../../src/grlida_info.cpp" line="73"/>
         <location filename="../../src/grlida_info.cpp" line="76"/>
-        <source>VersiÃ³n</source>
+        <source>Versión</source>
         <translation>Version</translation>
     </message>
     <message>
@@ -7421,12 +7421,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Slet...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7436,7 +7436,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Quieres eliminar de la lista?</source>
+        <source>¿Quieres eliminar de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7472,12 +7472,12 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="828"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation type="unfinished">Der opstod en fejl i processen, tid efter start med succes</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="831"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation type="unfinished">Der opstod en fejl, vent ... () Sidste gang out funktion</translation>
     </message>
     <message>
@@ -7496,7 +7496,7 @@ Ikke gemte data eller ændringer vil gå tabt.</translation>
         <translation type="unfinished">Der opstod en ukendt fejl</translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">Ønsker du at fjerne ISO fra listen?</translation>
     </message>
     <message>
@@ -8052,7 +8052,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="417"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titel</translation>
     </message>
     <message>
@@ -8068,7 +8068,7 @@ Tjek, om programmet virkelig er installeret.</translation>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="700"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1002"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1042"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Understøttede billeder</translation>
     </message>
     <message>
@@ -8102,7 +8102,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="915"/>
-        <source>PuntuaciÃ³n</source>
+        <source>Puntuación</source>
         <translation>Score</translation>
     </message>
     <message>
@@ -8122,52 +8122,52 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1063"/>
-        <source>DÃ­a del mes sin ceros iniciales (1 a 31).</source>
+        <source>Día del mes sin ceros iniciales (1 a 31).</source>
         <translation>Dag i den måned, uden et foranstillet nul (1 til 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1067"/>
-        <source>DÃ­a del mes, 2 dÃ­gitos con ceros iniciales (01 a 31).</source>
+        <source>Día del mes, 2 dígitos con ceros iniciales (01 a 31).</source>
         <translation>Dag i måneden med et foranstillet nul (01 til 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1071"/>
-        <source>Una representaciÃ³n textual de un dÃ­a, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
+        <source>Una representación textual de un día, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
         <translation>Forkortet dag navn (f.eks&apos; man &apos;til&apos; søn &apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1075"/>
-        <source>Una representaciÃ³n textual completa del dÃ­a de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
+        <source>Una representación textual completa del día de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
         <translation>Heldags navn (f.eks&apos; man &apos;til&apos; søndag &apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1079"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, sin ceros iniciales (1-12).</source>
+        <source>Representación numérica de un mes, sin ceros iniciales (1-12).</source>
         <translation>Måneden som et tal uden et foranstillet nul (1-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1083"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, con ceros iniciales (01-12).</source>
+        <source>Representación numérica de un mes, con ceros iniciales (01-12).</source>
         <translation>Måneden som et tal med et foranstillet nul (01-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1087"/>
-        <source>Una representaciÃ³n textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
+        <source>Una representación textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
         <translation>Forkortet måned navn (f.eks &quot;jan&quot; til &quot;dec&quot;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1091"/>
-        <source>Una representaciÃ³n textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
+        <source>Una representación textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
         <translation>Fuld måned navn (f.eks &quot;januar&quot; til &quot;december&quot;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1095"/>
-        <source>Una representaciÃ³n de dos dÃ­gitos de un aÃ±o (00-99).</source>
+        <source>Una representación de dos dígitos de un año (00-99).</source>
         <translation>År som et to-cifret antal (00-99).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1099"/>
-        <source>Una representaciÃ³n numÃ©rica completa de un aÃ±o, 4 dÃ­gitos.</source>
+        <source>Una representación numérica completa de un año, 4 dígitos.</source>
         <translation>År som et firecifret nummer.</translation>
     </message>
     <message>
@@ -8196,12 +8196,12 @@ Tjek, om programmet virkelig er installeret.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1200"/>
         <location filename="../../src/grlida_opciones.cpp" line="1463"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation>Du skal sætte en titel.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1410"/>
-        <source>Â¿Deseas realmente eliminar este DOSBox de la lista?</source>
+        <source>¿Deseas realmente eliminar este DOSBox de la lista?</source>
         <translation>Vil du virkelig ønsker at fjerne denne DOSBox fra listen?</translation>
     </message>
     <message>
@@ -8211,17 +8211,17 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1601"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation>Vil du virkelig ønsker at slette denne emulator fra listen?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1672"/>
-        <source>Debes poner el nombre de la tabla para la nueva categorÃ­a.</source>
+        <source>Debes poner el nombre de la tabla para la nueva categoría.</source>
         <translation>Du skal indtaste et tabel navn til den nye kategori.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1676"/>
-        <source>Debes poner el tÃ­tulo de la nueva categorÃ­a.</source>
+        <source>Debes poner el título de la nueva categoría.</source>
         <translation>Du skal indtaste navnet på den nye kategori.</translation>
     </message>
     <message>
@@ -8244,27 +8244,27 @@ Tjek, om programmet virkelig er installeret.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1687"/>
         <location filename="../../src/grlida_opciones.cpp" line="1700"/>
-        <source>Â¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
+        <source>¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
         <translation>Tabellen allerede eksisterer. Ønsker du at bruge følgende navn til bordet?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1721"/>
-        <source>No se ha podido aÃ±adir la nueva categorÃ­a.</source>
+        <source>No se ha podido añadir la nueva categoría.</source>
         <translation>Kunne ikke tilføje den nye kategori.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1733"/>
-        <source>No se ha podido actualizar la categorÃ­a.</source>
+        <source>No se ha podido actualizar la categoría.</source>
         <translation>Kunne ikke opdatere kategori.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1843"/>
-        <source>Por favor selecciona una categorÃ­a de la lista para eliminarla</source>
+        <source>Por favor selecciona una categoría de la lista para eliminarla</source>
         <translation>Vælg en kategori på listen til at slette</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1846"/>
-        <source>No se puede eliminar la tabla de la categorÃ­a.</source>
+        <source>No se puede eliminar la tabla de la categoría.</source>
         <translation>Kan ikke slette denne tabel fra kategori.</translation>
     </message>
     <message>
@@ -8279,42 +8279,42 @@ Tjek, om programmet virkelig er installeret.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Slet...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1848"/>
-        <source>Â¿Deseas realmente eliminar esta categorÃ­a de la base de datos?</source>
+        <source>¿Deseas realmente eliminar esta categoría de la base de datos?</source>
         <translation>Vil du virkelig slette denne kategori fra databasen?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2021"/>
-        <source>Â¿Deseas restaurar el menÃº de navegaciÃ³n por defecto?</source>
+        <source>¿Deseas restaurar el menú de navegación por defecto?</source>
         <translation>Ønsker du at gendanne standard navigationsmenu?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2050"/>
-        <source>Por favor selecciona un menÃº nav de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú nav de la lista para eliminarlo</source>
         <translation>Vælg en navigationsmenu fra liste for at slette</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2052"/>
-        <source>Â¿Deseas realmente eliminar este menÃº nav de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú nav de la base de datos?</source>
         <translation>Vil du virkelig ønsker at slette denne navigationsmenuen fra databasen?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2223"/>
-        <source>Â¿Deseas restaurar el menÃº de shortcut por defecto?</source>
+        <source>¿Deseas restaurar el menú de shortcut por defecto?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2256"/>
-        <source>Por favor selecciona un menÃº shortcut de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú shortcut de la lista para eliminarlo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2258"/>
-        <source>Â¿Deseas realmente eliminar este menÃº shortcut de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú shortcut de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8326,7 +8326,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2449"/>
         <location filename="../../src/grlida_opciones.cpp" line="2517"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titel</translation>
     </message>
     <message>
@@ -8384,7 +8384,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="880"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Udgiver</translation>
     </message>
     <message>
@@ -8425,14 +8425,14 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="888"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>År</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="889"/>
         <location filename="../../src/grlida_opciones.cpp" line="913"/>
         <location filename="../../src/grlida_opciones.cpp" line="932"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Antal discs</translation>
     </message>
     <message>
@@ -8442,7 +8442,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="891"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafik</translation>
     </message>
     <message>
@@ -8479,7 +8479,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="899"/>
         <location filename="../../src/grlida_opciones.cpp" line="916"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Karakter</translation>
     </message>
     <message>
@@ -8504,7 +8504,7 @@ Tjek, om programmet virkelig er installeret.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="906"/>
         <location filename="../../src/grlida_opciones.cpp" line="926"/>
         <location filename="../../src/grlida_opciones.cpp" line="2033"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Udgiver</translation>
     </message>
     <message>
@@ -8542,7 +8542,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="912"/>
         <location filename="../../src/grlida_opciones.cpp" line="2034"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>År</translation>
     </message>
     <message>
@@ -8627,12 +8627,12 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="999"/>
-        <source>El proxy se determina sobre la base de la aplicaciÃ³n</source>
+        <source>El proxy se determina sobre la base de la aplicación</source>
         <translation>Info om dato og tidspunkt format</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1002"/>
-        <source>HTTP proxy sÃ³lo para las solicitudes</source>
+        <source>HTTP proxy sólo para las solicitudes</source>
         <translation>Tilnærmelse til kun HTTP-anmodninger</translation>
     </message>
     <message>
@@ -8679,7 +8679,7 @@ Tjek, om programmet virkelig er installeret.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="393"/>
         <location filename="../../src/grlida_opciones.cpp" line="500"/>
         <location filename="../../src/grlida_opciones.cpp" line="2437"/>
-        <source>ImÃ¡genes CategorÃ­as</source>
+        <source>Imágenes Categorías</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8690,14 +8690,14 @@ Tjek, om programmet virkelig er installeret.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="396"/>
         <location filename="../../src/grlida_opciones.cpp" line="503"/>
         <location filename="../../src/grlida_opciones.cpp" line="2439"/>
-        <source>ImÃ¡genes defecto</source>
+        <source>Imágenes defecto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="324"/>
         <location filename="../../src/grlida_opciones.cpp" line="350"/>
         <location filename="../../src/grlida_opciones.cpp" line="506"/>
-        <source>ImÃ¡genes idiomas</source>
+        <source>Imágenes idiomas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8722,7 +8722,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="989"/>
-        <source>TÃ­tulo descriptivo</source>
+        <source>Título descriptivo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8731,13 +8731,13 @@ Tjek, om programmet virkelig er installeret.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="992"/>
         <location filename="../../src/grlida_opciones.cpp" line="993"/>
         <location filename="../../src/grlida_opciones.cpp" line="994"/>
-        <source>TÃ­tulo Juego</source>
+        <source>Título Juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1050"/>
         <location filename="../../src/grlida_opciones.cpp" line="1161"/>
-        <source>InformaciÃ³n sobre el formato de la fecha y hora</source>
+        <source>Información sobre el formato de la fecha y hora</source>
         <translation>Info om dato og tidspunkt format</translation>
     </message>
     <message>
@@ -8747,13 +8747,13 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1053"/>
-        <source>Lista bÃ¡sica de parÃ¡metros:</source>
+        <source>Lista básica de parámetros:</source>
         <translation>Grundlæggende liste over parametre:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1057"/>
         <location filename="../../src/grlida_opciones.cpp" line="1106"/>
-        <source>ExpresiÃ³n</source>
+        <source>Expresión</source>
         <translation>Expression</translation>
     </message>
     <message>
@@ -8853,7 +8853,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2602"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Understøttede billeder</translation>
     </message>
     <message>
@@ -8865,7 +8865,7 @@ Tjek, om programmet virkelig er installeret.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <source>¿Deseas eliminar la extensión?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8885,7 +8885,7 @@ Tjek, om programmet virkelig er installeret.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2628"/>
-        <source>Â¿Deseas realmente eliminar este dato de la lista?</source>
+        <source>¿Deseas realmente eliminar este dato de la lista?</source>
         <translation>Vil du virkelig ønsker at slette dette element fra listen?</translation>
     </message>
     <message>
@@ -10214,12 +10214,12 @@ Klik på &apos;OK&apos; for at afslutte denne guide
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="532"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Du skal angive mindst titlen.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="573"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Du skal angive spillets titel</translation>
     </message>
     <message>
@@ -10242,22 +10242,22 @@ Klik på &apos;OK&apos; for at afslutte denne guide
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Slet montering indstillinger?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Ønsker du at slette denne montering?</translation>
     </message>
     <message>
@@ -10505,12 +10505,12 @@ Klik på &apos;OK&apos; for at afslutte denne guide
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="375"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Du skal angive mindst titlen.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="415"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Du skal angive spillets titel</translation>
     </message>
     <message>
@@ -10594,7 +10594,7 @@ Klik på &apos;OK&apos; for at afslutte denne guide
     </message>
     <message>
         <location filename="../../src/grlida_wizard_vdmsound.cpp" line="268"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Du skal angive mindst titlen.</translation>
     </message>
     <message>

--- a/res/idiomas/gr-lida_en_EN.ts
+++ b/res/idiomas/gr-lida_en_EN.ts
@@ -101,12 +101,12 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="359"/>
-        <source>SuperÃ­ndice</source>
+        <source>Superíndice</source>
         <translation>Supindex</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="362"/>
-        <source>SubÃ­ndice</source>
+        <source>Subíndice</source>
         <translation>Subindex</translation>
     </message>
     <message>
@@ -121,22 +121,22 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="396"/>
-        <source>CÃ³digo</source>
+        <source>Código</source>
         <translation>Code</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="433"/>
-        <source>Coincidir mayÃºsculas/minÃºsculas</source>
+        <source>Coincidir mayúsculas/minúsculas</source>
         <translation>Match uppercase / lowercase</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1125"/>
-        <source>ImÃ¡genes</source>
+        <source>Imágenes</source>
         <translation>Images</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1130"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Supported images</translation>
     </message>
     <message>
@@ -242,12 +242,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿Sobrescribir?</source>
+        <source>¿Sobrescribir?</source>
         <translation>Overwrite?</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿El archivo &apos;</source>
+        <source>¿El archivo &apos;</source>
         <translation>File &apos;</translation>
     </message>
     <message>
@@ -257,7 +257,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1004"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Front cover</translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1006"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Qualification</translation>
     </message>
     <message>
@@ -282,7 +282,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1009"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Subtitle</translation>
     </message>
     <message>
@@ -362,12 +362,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1024"/>
-        <source>AÃ±adido el</source>
+        <source>Añadido el</source>
         <translation>Added the</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1025"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphics</translation>
     </message>
     <message>
@@ -397,7 +397,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1031"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
@@ -407,17 +407,17 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1033"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1037"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Title</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1038"/>
-        <source>TÃ­tulo album</source>
+        <source>Título album</source>
         <translation>Title album</translation>
     </message>
     <message>
@@ -427,7 +427,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="2041"/>
-        <source>ConfiguraciÃ³n por defecto</source>
+        <source>Configuración por defecto</source>
         <translation>Default configuration</translation>
     </message>
     <message>
@@ -792,43 +792,43 @@
         <location filename="../../src/grdap.cpp" line="874"/>
         <location filename="../../src/grdap.cpp" line="880"/>
         <location filename="../../src/grdap.cpp" line="949"/>
-        <source>Âº</source>
+        <source>º</source>
         <translation>º</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="443"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Size</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="495"/>
         <location filename="../../src/grdap.cpp" line="530"/>
-        <source>Seleccione la configuraciÃ³n que quieres abrir.</source>
+        <source>Seleccione la configuración que quieres abrir.</source>
         <translation>Select the configuration you want to open.</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="587"/>
-        <source>TÃ­tulo del juego</source>
+        <source>Título del juego</source>
         <translation>Title of the game</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="590"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="725"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Page</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="799"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Protection Roulette</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="800"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Supported images</translation>
     </message>
     <message>
@@ -1966,7 +1966,7 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3358"/>
-        <source>Eliminar imÃ¡genes.</source>
+        <source>Eliminar imágenes.</source>
         <translation>Remove images.</translation>
     </message>
     <message>
@@ -2104,17 +2104,17 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3313"/>
-        <source>Â¿Eliminar juego...?</source>
+        <source>¿Eliminar juego...?</source>
         <translation>Delete game ...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3321"/>
-        <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation>Do you really want to delete this game from the database?</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3325"/>
-        <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
+        <source>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</source>
         <translation>If it is DOSBox or VDMSound, the configuration file is also deleted.</translation>
     </message>
     <message>
@@ -2124,17 +2124,17 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3341"/>
-        <source>Eliminar carÃ¡tula thumbs.</source>
+        <source>Eliminar carátula thumbs.</source>
         <translation>Remove cover thumbs.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3345"/>
-        <source>Eliminar imÃ¡genes de la caja.</source>
+        <source>Eliminar imágenes de la caja.</source>
         <translation>Remove images from the box.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3350"/>
-        <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
+        <source>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation>Cover front, back, left side, right, up, down.</translation>
     </message>
     <message>
@@ -2159,12 +2159,12 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3417"/>
-        <source>CarÃ¡tula</source>
+        <source>Carátula</source>
         <translation>Cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3424"/>
-        <source>ImÃ¡genes de la caja.</source>
+        <source>Imágenes de la caja.</source>
         <translation>Pictures of the box.</translation>
     </message>
     <message>
@@ -2174,7 +2174,7 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3443"/>
-        <source>ImÃ¡genes del juego</source>
+        <source>Imágenes del juego</source>
         <translation>Images of the game</translation>
     </message>
     <message>
@@ -2184,17 +2184,17 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3477"/>
-        <source>ConfiguraciÃ³n de DOSBox</source>
+        <source>Configuración de DOSBox</source>
         <translation>Configuration of DOSBox</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3495"/>
-        <source>ConfiguraciÃ³n de ScummVM</source>
+        <source>Configuración de ScummVM</source>
         <translation>Configuration of ScummVM</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3503"/>
-        <source>ConfiguraciÃ³n de VDMSound</source>
+        <source>Configuración de VDMSound</source>
         <translation>Configuration of VDMSound</translation>
     </message>
     <message>
@@ -2230,12 +2230,12 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5112"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>An error occurred in the process, time after successfully starting</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5115"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>An error has occurred, waitFor ... () Last function the timeout</translation>
     </message>
     <message>
@@ -2261,8 +2261,8 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="376"/>
-        <source>No se ha podido establecer una conexiÃ³n con la base de datos.
-Esta aplicaciÃ³n necesita soporte de SQLite. Mira la documentaciÃ³n de Qt SQL driver para mÃ¡s informaciÃ³n.
+        <source>No se ha podido establecer una conexión con la base de datos.
+Esta aplicación necesita soporte de SQLite. Mira la documentación de Qt SQL driver para más información.
 
 Click cancelar para salir.</source>
         <translation>Could not establish a connection to the database.
@@ -2272,58 +2272,58 @@ Click cancel to exit.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1584"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information not available</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1653"/>
         <location filename="../../src/grlida.cpp" line="2094"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Title</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1654"/>
         <location filename="../../src/grlida.cpp" line="2095"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Subtitle</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1656"/>
         <location filename="../../src/grlida.cpp" line="2097"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Publisher</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1661"/>
         <location filename="../../src/grlida.cpp" line="2105"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Year</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1662"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1664"/>
         <location filename="../../src/grlida.cpp" line="2109"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphics</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2106"/>
-        <source>NÂº Discos</source>
+        <source>Nº Discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2108"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Size</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2263"/>
         <location filename="../../src/grlida.cpp" line="2825"/>
-        <source>NÂº juegos</source>
+        <source>Nº juegos</source>
         <translation>Game</translation>
     </message>
     <message>
@@ -2446,12 +2446,12 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="319"/>
-        <source>Â¿Redireccionar a &apos;%1&apos;?</source>
+        <source>¿Redireccionar a &apos;%1&apos;?</source>
         <translation>Redirect to &apos;%1&apos;?</translation>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="402"/>
-        <source>Uno o mÃ¡s errores de SSL se ha producido: %1</source>
+        <source>Uno o más errores de SSL se ha producido: %1</source>
         <translation>One or more SSL errors occurred:%1</translation>
     </message>
     <message>
@@ -2533,7 +2533,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="46"/>
-        <source>Cargando configuraciÃ³n...</source>
+        <source>Cargando configuración...</source>
         <translation>Loading settings ...</translation>
     </message>
     <message>
@@ -2661,12 +2661,12 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="882"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Publisher</translation>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="883"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Year</translation>
     </message>
     <message>
@@ -2684,12 +2684,12 @@ Please check the media service plugins are installed.</source>
     <name>frmAcercaD</name>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="68"/>
-        <source>es un lanzador comÃºn para los emuladores:</source>
+        <source>es un lanzador común para los emuladores:</source>
         <translation>is a common launcher for emulators:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="70"/>
-        <source>es GPL. Para mejorar el programa puedes dejar tu opiniÃ³n en</source>
+        <source>es GPL. Para mejorar el programa puedes dejar tu opinión en</source>
         <translation>It is GPL. To improve the program you can leave your opinion in</translation>
     </message>
     <message>
@@ -2854,22 +2854,22 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation>Use mounts?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation>Do you want to add used mounts?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Remove mount...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Do you want to delete this mount?</translation>
     </message>
     <message>
@@ -4234,12 +4234,12 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="86"/>
-        <source>Â¿Cerrar ventana?</source>
+        <source>¿Cerrar ventana?</source>
         <translation>Close the window?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="87"/>
-        <source>Â¿Deseas realmente cerrar la ventana?
+        <source>¿Deseas realmente cerrar la ventana?
 Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios efectuados.</source>
         <translation>Do you really want to close the window?
 If they are new data or you have made changes and do not save you can lose the changes made.</translation>
@@ -4255,7 +4255,7 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="385"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2584"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Protection Roulette</translation>
     </message>
     <message>
@@ -4265,32 +4265,32 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="390"/>
-        <source>CarÃ¡tula delantera</source>
+        <source>Carátula delantera</source>
         <translation>Front cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="391"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Back cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="392"/>
-        <source>CarÃ¡tula izquierda</source>
+        <source>Carátula izquierda</source>
         <translation>Cover left</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="393"/>
-        <source>CarÃ¡tula derecha</source>
+        <source>Carátula derecha</source>
         <translation>Right cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="394"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation>Top cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="395"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation>Bottom cover</translation>
     </message>
     <message>
@@ -4300,7 +4300,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="441"/>
-        <source>AÃ±adiendo un nuevo juego</source>
+        <source>Añadiendo un nuevo juego</source>
         <translation>Adding a new game</translation>
     </message>
     <message>
@@ -4310,12 +4310,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1420"/>
-        <source>AÃ±adir grupo</source>
+        <source>Añadir grupo</source>
         <translation>Add group</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1455"/>
-        <source>AÃ±adir</source>
+        <source>Añadir</source>
         <translation>Add</translation>
     </message>
     <message>
@@ -4347,7 +4347,7 @@ If they are new data or you have made changes and do not save you can lose the c
         <location filename="../../src/grlida_addedit_juego.cpp" line="1725"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1783"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1874"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Supported images</translation>
     </message>
     <message>
@@ -4375,28 +4375,28 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1795"/>
-        <source>Â¿Deseas eliminar la imagen seleccionada?</source>
+        <source>¿Deseas eliminar la imagen seleccionada?</source>
         <translation>Do you want to delete the selected image?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
-        <source>Â¿Deseas eliminar la captura seleccionada?</source>
+        <source>¿Deseas eliminar la captura seleccionada?</source>
         <translation>Do you want to delete the selected capture?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
-        <source>Â¿Deseas eliminar el video seleccionado?</source>
+        <source>¿Deseas eliminar el video seleccionado?</source>
         <translation>Do you want to delete the selected video?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Deseas eliminar el sonido seleccionado?</source>
+        <source>¿Deseas eliminar el sonido seleccionado?</source>
         <translation>Do you want to delete the selected sound?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2096"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2194"/>
-        <source>Para aÃ±adir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
+        <source>Para añadir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
         <translation>To add compatibility options you must indicate at least one executable.</translation>
     </message>
     <message>
@@ -4416,22 +4416,22 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Eliminar url...?</source>
+        <source>¿Eliminar url...?</source>
         <translation>Remove url ...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Deseas eliminar esta url?</source>
+        <source>¿Deseas eliminar esta url?</source>
         <translation>Do you want to delete this url?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Eliminar archivo...?</source>
+        <source>¿Eliminar archivo...?</source>
         <translation>Delete file...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Deseas eliminar este archivo?</source>
+        <source>¿Deseas eliminar este archivo?</source>
         <translation>Do you want to delete this file?</translation>
     </message>
     <message>
@@ -4473,7 +4473,7 @@ If they are new data or you have made changes and do not save you can lose the c
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Delete?</translation>
     </message>
     <message>
@@ -4547,17 +4547,17 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
-        <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
+        <source>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</source>
         <translation>Force the use of the ASPI layer. Only on Windows with an ASPI-Layer</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
-        <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
+        <source>Selección automática de la interfaz de audio de CD</source>
         <translation>Automatic selection of CD audio interface</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
-        <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
+        <source>Extracción digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio extraction used for audio CDs</translation>
     </message>
     <message>
@@ -4572,7 +4572,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
-        <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
+        <source>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</source>
         <translation>Force the use of SDLs for the CD-ROM. Valid for all systems</translation>
     </message>
     <message>
@@ -4592,12 +4592,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Delete?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation>Do you want to remove the ISO/IMA/IMG from the list?</translation>
     </message>
     <message>
@@ -5302,7 +5302,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="236"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation>You must specify the game title.</translation>
     </message>
     <message>
@@ -5348,12 +5348,12 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="361"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="390"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="386"/>
-        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuraciÃ³n.</source>
+        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuración.</source>
         <translation>Example with the virtual unit of Alcohol having the following configuration.</translation>
     </message>
     <message>
@@ -5384,17 +5384,17 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="434"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="437"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Information</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Delete?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation>Do you really want to remove this emulator from the list?</translation>
     </message>
     <message>
@@ -5486,12 +5486,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="60"/>
-        <source>A la categorÃ­a</source>
+        <source>A la categoría</source>
         <translation>To the category</translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="66"/>
-        <source>Selecciona la categorÃ­a de destino</source>
+        <source>Selecciona la categoría de destino</source>
         <translation>Select the destination category</translation>
     </message>
 </context>
@@ -5555,7 +5555,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_compatibilidad_exe.cpp" line="232"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Information</translation>
     </message>
     <message>
@@ -5662,7 +5662,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="61"/>
-        <source>DiseÃ±ado y programado por</source>
+        <source>Diseñado y programado por</source>
         <translation>Designed and programmed by</translation>
     </message>
     <message>
@@ -5682,7 +5682,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="62"/>
-        <source>Texto oculto en el manual del tipo Indiana Jones y la Ãltima Cruzada</source>
+        <source>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</source>
         <translation>Hidden text in the type manual Indiana Jones and the Last Crusade</translation>
     </message>
 </context>
@@ -5760,7 +5760,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="76"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Title</translation>
     </message>
     <message>
@@ -5770,12 +5770,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="80"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Subtitle</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="145"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
@@ -5785,12 +5785,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="157"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Size</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="162"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphics</translation>
     </message>
     <message>
@@ -5834,32 +5834,32 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="187"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Front cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="192"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Back cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="197"/>
-        <source>CarÃ¡tula lateral izquierdo</source>
+        <source>Carátula lateral izquierdo</source>
         <translation>Left side cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="202"/>
-        <source>CarÃ¡tula lateral derecho</source>
+        <source>Carátula lateral derecho</source>
         <translation>Right side cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="207"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation>Top cover</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="212"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation>Bottom cover</translation>
     </message>
     <message>
@@ -5889,7 +5889,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="239"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
@@ -6531,7 +6531,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_dosbox.cpp" line="660"/>
-        <source>Config - DespuÃ©s del exe</source>
+        <source>Config - Después del exe</source>
         <translation>Config - After the exe</translation>
     </message>
     <message>
@@ -6616,23 +6616,23 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="164"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Information</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="192"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1432"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Page</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="260"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Title</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="261"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Year</translation>
     </message>
     <message>
@@ -6643,12 +6643,12 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="293"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="308"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="294"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Size</translation>
     </message>
     <message>
@@ -6665,7 +6665,7 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="420"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="779"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information not available</translation>
     </message>
     <message>
@@ -6735,13 +6735,13 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="1851"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1872"/>
-        <source>AÃ±adiendo a la lista</source>
+        <source>Añadiendo a la lista</source>
         <translation>Adding to the list</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="2776"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="2780"/>
-        <source>Importando imÃ¡genes, juego</source>
+        <source>Importando imágenes, juego</source>
         <translation>Importing images, game</translation>
     </message>
     <message>
@@ -7102,12 +7102,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="71"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="101"/>
-        <source>Modo grÃ¡fico:</source>
+        <source>Modo gráfico:</source>
         <translation>Graphic mode:</translation>
     </message>
     <message>
@@ -7162,7 +7162,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="148"/>
-        <source>Mostras subtÃ­tulo</source>
+        <source>Mostras subtítulo</source>
         <translation>Show subtitles</translation>
     </message>
     <message>
@@ -7172,12 +7172,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="154"/>
-        <source>Filtro de grÃ¡ficos</source>
+        <source>Filtro de gráficos</source>
         <translation>Graphics filters</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="157"/>
-        <source>CorrecciÃ³n de aspecto</source>
+        <source>Corrección de aspecto</source>
         <translation>Aspect correction</translation>
     </message>
     <message>
@@ -7232,7 +7232,7 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="206"/>
-        <source>Volumen mÃºsica:</source>
+        <source>Volumen música:</source>
         <translation>Music volume:</translation>
     </message>
     <message>
@@ -7247,12 +7247,12 @@ If they are new data or you have made changes and do not save you can lose the c
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="215"/>
-        <source>Tiempo de la mÃºsica:</source>
+        <source>Tiempo de la música:</source>
         <translation>Music tempo:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="218"/>
-        <source>Velocidad de subtÃ­tulos:</source>
+        <source>Velocidad de subtítulos:</source>
         <translation>Speed  subtitles:</translation>
     </message>
     <message>
@@ -7301,7 +7301,7 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_info.cpp" line="73"/>
         <location filename="../../src/grlida_info.cpp" line="76"/>
-        <source>VersiÃ³n</source>
+        <source>Versión</source>
         <translation>Version</translation>
     </message>
     <message>
@@ -7421,12 +7421,12 @@ If they are new data or you have made changes and do not save you can lose the c
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Delete?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation>Do you want to remove the ISO/IMA/IMG from the list?</translation>
     </message>
     <message>
@@ -7448,7 +7448,7 @@ or the destination folder is wrong.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Quieres eliminar de la lista?</source>
+        <source>¿Quieres eliminar de la lista?</source>
         <translation>Do you want to remove from the list?</translation>
     </message>
     <message>
@@ -7484,12 +7484,12 @@ or the destination folder is wrong.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="828"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>An error occurred in the process, time after successfully starting</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="831"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>An error has occurred, waitFor ... () Last function the timeout</translation>
     </message>
     <message>
@@ -8048,7 +8048,7 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="417"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Title</translation>
     </message>
     <message>
@@ -8064,7 +8064,7 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="700"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1002"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1042"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Supported images</translation>
     </message>
     <message>
@@ -8098,48 +8098,48 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="888"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Year</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="889"/>
         <location filename="../../src/grlida_opciones.cpp" line="913"/>
         <location filename="../../src/grlida_opciones.cpp" line="932"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Number of disks</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="891"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphics</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="899"/>
         <location filename="../../src/grlida_opciones.cpp" line="916"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Qualification</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="906"/>
         <location filename="../../src/grlida_opciones.cpp" line="926"/>
         <location filename="../../src/grlida_opciones.cpp" line="2033"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Publisher</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="912"/>
         <location filename="../../src/grlida_opciones.cpp" line="2034"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Year</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="915"/>
-        <source>PuntuaciÃ³n</source>
+        <source>Puntuación</source>
         <translation>Score</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="989"/>
-        <source>TÃ­tulo descriptivo</source>
+        <source>Título descriptivo</source>
         <translation>Descriptive title</translation>
     </message>
     <message>
@@ -8148,7 +8148,7 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="992"/>
         <location filename="../../src/grlida_opciones.cpp" line="993"/>
         <location filename="../../src/grlida_opciones.cpp" line="994"/>
-        <source>TÃ­tulo Juego</source>
+        <source>Título Juego</source>
         <translation>Title Game</translation>
     </message>
     <message>
@@ -8158,7 +8158,7 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="999"/>
-        <source>El proxy se determina sobre la base de la aplicaciÃ³n</source>
+        <source>El proxy se determina sobre la base de la aplicación</source>
         <translation>The proxy is determined based on the application</translation>
     </message>
     <message>
@@ -8173,74 +8173,74 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1002"/>
-        <source>HTTP proxy sÃ³lo para las solicitudes</source>
+        <source>HTTP proxy sólo para las solicitudes</source>
         <translation>HTTP proxy only for requests</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1050"/>
         <location filename="../../src/grlida_opciones.cpp" line="1161"/>
-        <source>InformaciÃ³n sobre el formato de la fecha y hora</source>
+        <source>Información sobre el formato de la fecha y hora</source>
         <translation>Information about the date and time format</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1053"/>
-        <source>Lista bÃ¡sica de parÃ¡metros:</source>
+        <source>Lista básica de parámetros:</source>
         <translation>Basic list of parameters:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1057"/>
         <location filename="../../src/grlida_opciones.cpp" line="1106"/>
-        <source>ExpresiÃ³n</source>
+        <source>Expresión</source>
         <translation>Expression</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1063"/>
-        <source>DÃ­a del mes sin ceros iniciales (1 a 31).</source>
+        <source>Día del mes sin ceros iniciales (1 a 31).</source>
         <translation>Day of the month without initial zeros (1 to 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1067"/>
-        <source>DÃ­a del mes, 2 dÃ­gitos con ceros iniciales (01 a 31).</source>
+        <source>Día del mes, 2 dígitos con ceros iniciales (01 a 31).</source>
         <translation>Day of the month, 2 digits with leading zeros (01 to 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1071"/>
-        <source>Una representaciÃ³n textual de un dÃ­a, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
+        <source>Una representación textual de un día, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
         <translation>A textual representation of a day, three letters (e.j. &apos;Mon&apos; to &apos;Sun&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1075"/>
-        <source>Una representaciÃ³n textual completa del dÃ­a de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
+        <source>Una representación textual completa del día de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
         <translation>A complete textual representation of the day of the week (e.j. &apos;Monday&apos; to &apos;Sunday&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1079"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, sin ceros iniciales (1-12).</source>
+        <source>Representación numérica de un mes, sin ceros iniciales (1-12).</source>
         <translation>Numerical representation of a month, without initial zeros (1-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1083"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, con ceros iniciales (01-12).</source>
+        <source>Representación numérica de un mes, con ceros iniciales (01-12).</source>
         <translation>Numerical representation of a month, with initial zeros (01-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1087"/>
-        <source>Una representaciÃ³n textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
+        <source>Una representación textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
         <translation>A short textual representation of a month, three letters (e.j. &apos;Jan&apos; to &apos;Dec&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1091"/>
-        <source>Una representaciÃ³n textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
+        <source>Una representación textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
         <translation>A complete textual representation of a month, such as January or March (e.j. &apos;January&apos; to &apos;December&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1095"/>
-        <source>Una representaciÃ³n de dos dÃ­gitos de un aÃ±o (00-99).</source>
+        <source>Una representación de dos dígitos de un año (00-99).</source>
         <translation>A two-digit representation of a year (00-99).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1099"/>
-        <source>Una representaciÃ³n numÃ©rica completa de un aÃ±o, 4 dÃ­gitos.</source>
+        <source>Una representación numérica completa de un año, 4 dígitos.</source>
         <translation>A full numerical representation of one year, 4 digits.</translation>
     </message>
     <message>
@@ -8269,7 +8269,7 @@ Check if the program is really installed.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1200"/>
         <location filename="../../src/grlida_opciones.cpp" line="1463"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation>You must specify the game title.</translation>
     </message>
     <message>
@@ -8284,12 +8284,12 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Delete?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1410"/>
-        <source>Â¿Deseas realmente eliminar este DOSBox de la lista?</source>
+        <source>¿Deseas realmente eliminar este DOSBox de la lista?</source>
         <translation>Do you really want to delete this DOSBox from the list?</translation>
     </message>
     <message>
@@ -8299,17 +8299,17 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1601"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation>Do you really want to remove this emulator from the list?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1672"/>
-        <source>Debes poner el nombre de la tabla para la nueva categorÃ­a.</source>
+        <source>Debes poner el nombre de la tabla para la nueva categoría.</source>
         <translation>You must put the name of the table for the new category.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1676"/>
-        <source>Debes poner el tÃ­tulo de la nueva categorÃ­a.</source>
+        <source>Debes poner el título de la nueva categoría.</source>
         <translation>You must put the title of the new category.</translation>
     </message>
     <message>
@@ -8322,7 +8322,7 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <source>¿Deseas eliminar la extensión?</source>
         <translation>Do you want to remove this extension?</translation>
     </message>
     <message>
@@ -8339,62 +8339,62 @@ Check if the program is really installed.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1687"/>
         <location filename="../../src/grlida_opciones.cpp" line="1700"/>
-        <source>Â¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
+        <source>¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
         <translation>The table already exists, do you want to use the following name for the table?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1721"/>
-        <source>No se ha podido aÃ±adir la nueva categorÃ­a.</source>
+        <source>No se ha podido añadir la nueva categoría.</source>
         <translation>The new category could not be added.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1733"/>
-        <source>No se ha podido actualizar la categorÃ­a.</source>
+        <source>No se ha podido actualizar la categoría.</source>
         <translation>The category could not be updated.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1843"/>
-        <source>Por favor selecciona una categorÃ­a de la lista para eliminarla</source>
+        <source>Por favor selecciona una categoría de la lista para eliminarla</source>
         <translation>Please select a category from the list to remove it</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1846"/>
-        <source>No se puede eliminar la tabla de la categorÃ­a.</source>
+        <source>No se puede eliminar la tabla de la categoría.</source>
         <translation>The category table can not be deleted.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1848"/>
-        <source>Â¿Deseas realmente eliminar esta categorÃ­a de la base de datos?</source>
+        <source>¿Deseas realmente eliminar esta categoría de la base de datos?</source>
         <translation>Do you really want to delete this category from the database?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2021"/>
-        <source>Â¿Deseas restaurar el menÃº de navegaciÃ³n por defecto?</source>
+        <source>¿Deseas restaurar el menú de navegación por defecto?</source>
         <translation>Do you want to restore the default navigation menu?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2050"/>
-        <source>Por favor selecciona un menÃº nav de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú nav de la lista para eliminarlo</source>
         <translation>Please select a nav menu from the list to remove it</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2052"/>
-        <source>Â¿Deseas realmente eliminar este menÃº nav de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú nav de la base de datos?</source>
         <translation>Do you really want to delete this nav menu from the database?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2223"/>
-        <source>Â¿Deseas restaurar el menÃº de shortcut por defecto?</source>
+        <source>¿Deseas restaurar el menú de shortcut por defecto?</source>
         <translation>Do you want to restore the shortcut menu by default?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2256"/>
-        <source>Por favor selecciona un menÃº shortcut de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú shortcut de la lista para eliminarlo</source>
         <translation>Please select a shortcut menu from the list to remove it</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2258"/>
-        <source>Â¿Deseas realmente eliminar este menÃº shortcut de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú shortcut de la base de datos?</source>
         <translation>Do you really want to delete this shortcut menu from the database?</translation>
     </message>
     <message>
@@ -8467,7 +8467,7 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="880"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Publisher</translation>
     </message>
     <message>
@@ -8716,7 +8716,7 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="393"/>
         <location filename="../../src/grlida_opciones.cpp" line="500"/>
         <location filename="../../src/grlida_opciones.cpp" line="2437"/>
-        <source>ImÃ¡genes CategorÃ­as</source>
+        <source>Imágenes Categorías</source>
         <translation>Category icons</translation>
     </message>
     <message>
@@ -8727,14 +8727,14 @@ Check if the program is really installed.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="396"/>
         <location filename="../../src/grlida_opciones.cpp" line="503"/>
         <location filename="../../src/grlida_opciones.cpp" line="2439"/>
-        <source>ImÃ¡genes defecto</source>
+        <source>Imágenes defecto</source>
         <translation>defecto icons</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="324"/>
         <location filename="../../src/grlida_opciones.cpp" line="350"/>
         <location filename="../../src/grlida_opciones.cpp" line="506"/>
-        <source>ImÃ¡genes idiomas</source>
+        <source>Imágenes idiomas</source>
         <translation>Language icons</translation>
     </message>
     <message>
@@ -8859,7 +8859,7 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2602"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Supported images</translation>
     </message>
     <message>
@@ -8885,7 +8885,7 @@ Check if the program is really installed.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2449"/>
         <location filename="../../src/grlida_opciones.cpp" line="2517"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Title</translation>
     </message>
     <message>
@@ -8896,7 +8896,7 @@ Check if the program is really installed.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2628"/>
-        <source>Â¿Deseas realmente eliminar este dato de la lista?</source>
+        <source>¿Deseas realmente eliminar este dato de la lista?</source>
         <translation>Do you really want to delete this data from the list?</translation>
     </message>
     <message>
@@ -10214,12 +10214,12 @@ Click &apos;OK&apos; to exit this wizard
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="532"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>You must specify at least the title.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="573"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>You must specify the game title</translation>
     </message>
     <message>
@@ -10242,22 +10242,22 @@ Click &apos;OK&apos; to exit this wizard
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation>Use mounts?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation>Do you want to add used mounts?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Remove mount...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Do you want to delete this mount?</translation>
     </message>
     <message>
@@ -10505,12 +10505,12 @@ Click &apos;OK&apos; to exit this wizard
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="375"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>You must specify at least the title.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="415"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>You must specify the game title</translation>
     </message>
     <message>
@@ -10599,7 +10599,7 @@ Click &apos;OK&apos; to exit this wizard
     </message>
     <message>
         <location filename="../../src/grlida_wizard_vdmsound.cpp" line="268"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>You must specify at least the title.</translation>
     </message>
     <message>

--- a/res/idiomas/gr-lida_es_ES.ts
+++ b/res/idiomas/gr-lida_es_ES.ts
@@ -101,12 +101,12 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="359"/>
-        <source>SuperÃ­ndice</source>
+        <source>Superíndice</source>
         <translation>Superíndice</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="362"/>
-        <source>SubÃ­ndice</source>
+        <source>Subíndice</source>
         <translation>Subí­ndice</translation>
     </message>
     <message>
@@ -121,22 +121,22 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="396"/>
-        <source>CÃ³digo</source>
+        <source>Código</source>
         <translation>Código</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="433"/>
-        <source>Coincidir mayÃºsculas/minÃºsculas</source>
+        <source>Coincidir mayúsculas/minúsculas</source>
         <translation>Coincidir mayúsculas/minúsculas</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1125"/>
-        <source>ImÃ¡genes</source>
+        <source>Imágenes</source>
         <translation>Imágenes</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1130"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Imágenes soportadas</translation>
     </message>
     <message>
@@ -242,12 +242,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿Sobrescribir?</source>
+        <source>¿Sobrescribir?</source>
         <translation>¿Sobrescribir?</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿El archivo &apos;</source>
+        <source>¿El archivo &apos;</source>
         <translation>¿El archivo &apos;</translation>
     </message>
     <message>
@@ -257,7 +257,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1004"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Carátula frontal</translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1006"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Calificación</translation>
     </message>
     <message>
@@ -282,7 +282,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1009"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Subtítulo</translation>
     </message>
     <message>
@@ -362,12 +362,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1024"/>
-        <source>AÃ±adido el</source>
+        <source>Añadido el</source>
         <translation>Añadido el</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1025"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Gráficos</translation>
     </message>
     <message>
@@ -397,7 +397,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1031"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Descripción</translation>
     </message>
     <message>
@@ -407,17 +407,17 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1033"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nº discos</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1037"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Título</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1038"/>
-        <source>TÃ­tulo album</source>
+        <source>Título album</source>
         <translation>Título album</translation>
     </message>
     <message>
@@ -427,7 +427,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="2041"/>
-        <source>ConfiguraciÃ³n por defecto</source>
+        <source>Configuración por defecto</source>
         <translation>Configuración por defecto</translation>
     </message>
     <message>
@@ -792,43 +792,43 @@
         <location filename="../../src/grdap.cpp" line="874"/>
         <location filename="../../src/grdap.cpp" line="880"/>
         <location filename="../../src/grdap.cpp" line="949"/>
-        <source>Âº</source>
+        <source>º</source>
         <translation>º</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="443"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Tamaño</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="495"/>
         <location filename="../../src/grdap.cpp" line="530"/>
-        <source>Seleccione la configuraciÃ³n que quieres abrir.</source>
+        <source>Seleccione la configuración que quieres abrir.</source>
         <translation>Seleccione la configuración que quieres abrir.</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="587"/>
-        <source>TÃ­tulo del juego</source>
+        <source>Título del juego</source>
         <translation>Tí­tulo del juego</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="590"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Descripción</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="725"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Página</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="799"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Ruleta de protección</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="800"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Imágenes soportadas</translation>
     </message>
     <message>
@@ -1957,8 +1957,8 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="376"/>
-        <source>No se ha podido establecer una conexiÃ³n con la base de datos.
-Esta aplicaciÃ³n necesita soporte de SQLite. Mira la documentaciÃ³n de Qt SQL driver para mÃ¡s informaciÃ³n.
+        <source>No se ha podido establecer una conexión con la base de datos.
+Esta aplicación necesita soporte de SQLite. Mira la documentación de Qt SQL driver para más información.
 
 Click cancelar para salir.</source>
         <translation>No se ha podido establecer una conexión con la base de datos.
@@ -1968,7 +1968,7 @@ Click cancelar para salir.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1584"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Información no disponible</translation>
     </message>
     <message>
@@ -1979,30 +1979,30 @@ Click cancelar para salir.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1653"/>
         <location filename="../../src/grlida.cpp" line="2094"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Título</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1654"/>
         <location filename="../../src/grlida.cpp" line="2095"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Subtítulo</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1656"/>
         <location filename="../../src/grlida.cpp" line="2097"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Compañia</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1661"/>
         <location filename="../../src/grlida.cpp" line="2105"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Año</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1662"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nº discos</translation>
     </message>
     <message>
@@ -2013,7 +2013,7 @@ Click cancelar para salir.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1664"/>
         <location filename="../../src/grlida.cpp" line="2109"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Gráficos</translation>
     </message>
     <message>
@@ -2034,12 +2034,12 @@ Click cancelar para salir.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2106"/>
-        <source>NÂº Discos</source>
+        <source>Nº Discos</source>
         <translation>Nº Discos</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2108"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Tamaño</translation>
     </message>
     <message>
@@ -2056,7 +2056,7 @@ Click cancelar para salir.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="2263"/>
         <location filename="../../src/grlida.cpp" line="2825"/>
-        <source>NÂº juegos</source>
+        <source>Nº juegos</source>
         <translation>Nº juegos</translation>
     </message>
     <message>
@@ -2153,17 +2153,17 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3313"/>
-        <source>Â¿Eliminar juego...?</source>
+        <source>¿Eliminar juego...?</source>
         <translation>¿Eliminar juego...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3321"/>
-        <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation>¿Deseas realmente eliminar este juego de la base de datos?</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3325"/>
-        <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
+        <source>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</source>
         <translation>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</translation>
     </message>
     <message>
@@ -2173,17 +2173,17 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3341"/>
-        <source>Eliminar carÃ¡tula thumbs.</source>
+        <source>Eliminar carátula thumbs.</source>
         <translation>Eliminar carátula thumbs.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3345"/>
-        <source>Eliminar imÃ¡genes de la caja.</source>
+        <source>Eliminar imágenes de la caja.</source>
         <translation>Eliminar imágenes de la caja.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3350"/>
-        <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
+        <source>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</translation>
     </message>
     <message>
@@ -2208,12 +2208,12 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3417"/>
-        <source>CarÃ¡tula</source>
+        <source>Carátula</source>
         <translation>Carátula</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3424"/>
-        <source>ImÃ¡genes de la caja.</source>
+        <source>Imágenes de la caja.</source>
         <translation>Imágenes de la caja.</translation>
     </message>
     <message>
@@ -2223,7 +2223,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3443"/>
-        <source>ImÃ¡genes del juego</source>
+        <source>Imágenes del juego</source>
         <translation>Imágenes del juego</translation>
     </message>
     <message>
@@ -2233,17 +2233,17 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3477"/>
-        <source>ConfiguraciÃ³n de DOSBox</source>
+        <source>Configuración de DOSBox</source>
         <translation>Configuración de DOSBox</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3495"/>
-        <source>ConfiguraciÃ³n de ScummVM</source>
+        <source>Configuración de ScummVM</source>
         <translation>Configuración de ScummVM</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3503"/>
-        <source>ConfiguraciÃ³n de VDMSound</source>
+        <source>Configuración de VDMSound</source>
         <translation>Configuración de VDMSound</translation>
     </message>
     <message>
@@ -2279,12 +2279,12 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5112"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>Se ha producido un error en el proceso, tiempo después de empezar con éxito</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5115"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>Se ha producido un error, waitFor...() Última función el tiempo de espera</translation>
     </message>
     <message>
@@ -2310,7 +2310,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3358"/>
-        <source>Eliminar imÃ¡genes.</source>
+        <source>Eliminar imágenes.</source>
         <translation>Eliminar imágenes.</translation>
     </message>
     <message>
@@ -2446,12 +2446,12 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="319"/>
-        <source>Â¿Redireccionar a &apos;%1&apos;?</source>
+        <source>¿Redireccionar a &apos;%1&apos;?</source>
         <translation>¿Redireccionar a &apos;%1&apos;?</translation>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="402"/>
-        <source>Uno o mÃ¡s errores de SSL se ha producido: %1</source>
+        <source>Uno o más errores de SSL se ha producido: %1</source>
         <translation>Uno o más errores de SSL se ha producido: %1</translation>
     </message>
     <message>
@@ -2533,7 +2533,7 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     </message>
     <message>
         <location filename="../../src/main.cpp" line="46"/>
-        <source>Cargando configuraciÃ³n...</source>
+        <source>Cargando configuración...</source>
         <translation>Cargando configuración...</translation>
     </message>
     <message>
@@ -2661,12 +2661,12 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="882"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Compañias</translation>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="883"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Años</translation>
     </message>
     <message>
@@ -2764,12 +2764,12 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     </message>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="68"/>
-        <source>es un lanzador comÃºn para los emuladores:</source>
+        <source>es un lanzador común para los emuladores:</source>
         <translation>es un lanzador común para los emuladores:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="70"/>
-        <source>es GPL. Para mejorar el programa puedes dejar tu opiniÃ³n en</source>
+        <source>es GPL. Para mejorar el programa puedes dejar tu opinión en</source>
         <translation>es GPL. Para mejorar el programa puedes dejar tu opinión en</translation>
     </message>
     <message>
@@ -3611,22 +3611,22 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation>¿Usar montajes?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation>¿Deseas añadir los montajes usados?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>¿Eliminar montaje...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>¿Deseas eliminar este montaje?</translation>
     </message>
     <message>
@@ -4215,12 +4215,12 @@ Por favor, compruebe que los complementos de servicio de medios están instalado
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="86"/>
-        <source>Â¿Cerrar ventana?</source>
+        <source>¿Cerrar ventana?</source>
         <translation>¿Cerrar ventana?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="87"/>
-        <source>Â¿Deseas realmente cerrar la ventana?
+        <source>¿Deseas realmente cerrar la ventana?
 Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios efectuados.</source>
         <translation>¿Deseas realmente cerrar la ventana?
 Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios efectuados.</translation>
@@ -4246,7 +4246,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="385"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2584"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Ruleta de protección</translation>
     </message>
     <message>
@@ -4256,32 +4256,32 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="390"/>
-        <source>CarÃ¡tula delantera</source>
+        <source>Carátula delantera</source>
         <translation>Carátula delantera</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="391"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Carátula trasera</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="392"/>
-        <source>CarÃ¡tula izquierda</source>
+        <source>Carátula izquierda</source>
         <translation>Carátula izquierda</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="393"/>
-        <source>CarÃ¡tula derecha</source>
+        <source>Carátula derecha</source>
         <translation>Carátula derecha</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="394"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation>Carátula superior</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="395"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation>Carátula inferior</translation>
     </message>
     <message>
@@ -4291,7 +4291,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="441"/>
-        <source>AÃ±adiendo un nuevo juego</source>
+        <source>Añadiendo un nuevo juego</source>
         <translation>Añadiendo un nuevo juego</translation>
     </message>
     <message>
@@ -4306,7 +4306,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1420"/>
-        <source>AÃ±adir grupo</source>
+        <source>Añadir grupo</source>
         <translation>Añadir grupo</translation>
     </message>
     <message>
@@ -4321,7 +4321,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1455"/>
-        <source>AÃ±adir</source>
+        <source>Añadir</source>
         <translation>Añadir</translation>
     </message>
     <message>
@@ -4353,7 +4353,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
         <location filename="../../src/grlida_addedit_juego.cpp" line="1725"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1783"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1874"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Imágenes soportadas</translation>
     </message>
     <message>
@@ -4384,33 +4384,33 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>¿Eliminar...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1795"/>
-        <source>Â¿Deseas eliminar la imagen seleccionada?</source>
+        <source>¿Deseas eliminar la imagen seleccionada?</source>
         <translation>¿Deseas eliminar la imagen seleccionada?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
-        <source>Â¿Deseas eliminar la captura seleccionada?</source>
+        <source>¿Deseas eliminar la captura seleccionada?</source>
         <translation>¿Deseas eliminar la captura seleccionada?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
-        <source>Â¿Deseas eliminar el video seleccionado?</source>
+        <source>¿Deseas eliminar el video seleccionado?</source>
         <translation>¿Deseas eliminar el video seleccionado?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Deseas eliminar el sonido seleccionado?</source>
+        <source>¿Deseas eliminar el sonido seleccionado?</source>
         <translation>¿Deseas eliminar el sonido seleccionado?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2096"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2194"/>
-        <source>Para aÃ±adir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
+        <source>Para añadir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
         <translation>Para añadir opciones de compatibilidad debes indicar un ejecutable como minimo.</translation>
     </message>
     <message>
@@ -4430,22 +4430,22 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Eliminar url...?</source>
+        <source>¿Eliminar url...?</source>
         <translation>¿Eliminar url...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Deseas eliminar esta url?</source>
+        <source>¿Deseas eliminar esta url?</source>
         <translation>¿Deseas eliminar esta url?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Eliminar archivo...?</source>
+        <source>¿Eliminar archivo...?</source>
         <translation>¿Eliminar archivo...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Deseas eliminar este archivo?</source>
+        <source>¿Deseas eliminar este archivo?</source>
         <translation>¿Deseas eliminar este archivo?</translation>
     </message>
     <message>
@@ -4598,22 +4598,22 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
-        <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
+        <source>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</source>
         <translation>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
-        <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
+        <source>Selección automática de la interfaz de audio de CD</source>
         <translation>Selección automática de la interfaz de audio de CD</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
-        <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
+        <source>Extracción digital de audio utilizado para los CD de audio</source>
         <translation>Extracción digital de audio utilizado para los CD de audio</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
-        <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
+        <source>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</source>
         <translation>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</translation>
     </message>
     <message>
@@ -4623,7 +4623,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation>¿Quieres eliminar la ISO/IMA/IMG de la lista?</translation>
     </message>
     <message>
@@ -4673,11 +4673,11 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>¿Eliminar...?</translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">¿Quieres eliminar la ISO de la lista?</translation>
     </message>
     <message>
@@ -5302,7 +5302,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="236"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation>Debes poner un tí­tulo.</translation>
     </message>
     <message>
@@ -5348,12 +5348,12 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="361"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="390"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Descripción</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="386"/>
-        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuraciÃ³n.</source>
+        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuración.</source>
         <translation></translation>
     </message>
     <message>
@@ -5384,17 +5384,17 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="434"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="437"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Información</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>¿Eliminar...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation>¿Deseas realmente eliminar este emulador de la lista?</translation>
     </message>
     <message>
@@ -5486,12 +5486,12 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="60"/>
-        <source>A la categorÃ­a</source>
+        <source>A la categoría</source>
         <translation>A la categoría</translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="66"/>
-        <source>Selecciona la categorÃ­a de destino</source>
+        <source>Selecciona la categoría de destino</source>
         <translation>Selecciona la categorí­a de destino</translation>
     </message>
 </context>
@@ -5555,7 +5555,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_compatibilidad_exe.cpp" line="232"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Información</translation>
     </message>
     <message>
@@ -5662,7 +5662,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="61"/>
-        <source>DiseÃ±ado y programado por</source>
+        <source>Diseñado y programado por</source>
         <translation>Diseñado y programado por</translation>
     </message>
     <message>
@@ -5682,8 +5682,8 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="62"/>
-        <source>Texto oculto en el manual del tipo Indiana Jones y la Ãltima Cruzada</source>
-        <translation>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</translation>
+        <source>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</source>
+        <translation>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</translation>
     </message>
 </context>
 <context>
@@ -5760,7 +5760,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="76"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Título</translation>
     </message>
     <message>
@@ -5770,12 +5770,12 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="80"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Subtítulo</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="145"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nº discos</translation>
     </message>
     <message>
@@ -5785,12 +5785,12 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="157"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Tamaño</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="162"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Gráficos</translation>
     </message>
     <message>
@@ -5834,32 +5834,32 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="187"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Carátula frontal</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="192"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Carátula trasera</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="197"/>
-        <source>CarÃ¡tula lateral izquierdo</source>
+        <source>Carátula lateral izquierdo</source>
         <translation>Carátula lateral izquierdo</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="202"/>
-        <source>CarÃ¡tula lateral derecho</source>
+        <source>Carátula lateral derecho</source>
         <translation>Carátula lateral derecho</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="207"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation>Carátula superior</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="212"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation>Carátula inferior</translation>
     </message>
     <message>
@@ -5889,7 +5889,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="239"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Descripción</translation>
     </message>
     <message>
@@ -6531,7 +6531,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_dosbox.cpp" line="660"/>
-        <source>Config - DespuÃ©s del exe</source>
+        <source>Config - Después del exe</source>
         <translation>Config - Después del exe</translation>
     </message>
     <message>
@@ -6862,7 +6862,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="164"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Información</translation>
     </message>
     <message>
@@ -6885,17 +6885,17 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="192"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1432"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Página</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="260"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Título</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="261"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Año</translation>
     </message>
     <message>
@@ -6906,12 +6906,12 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="293"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="308"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Descripción</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="294"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Tamaño</translation>
     </message>
     <message>
@@ -6928,7 +6928,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="420"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="779"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Información no disponible</translation>
     </message>
     <message>
@@ -6998,13 +6998,13 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="1851"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1872"/>
-        <source>AÃ±adiendo a la lista</source>
+        <source>Añadiendo a la lista</source>
         <translation>Añadiendo a la lista</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="2776"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="2780"/>
-        <source>Importando imÃ¡genes, juego</source>
+        <source>Importando imágenes, juego</source>
         <translation>Importando imágemes, juego</translation>
     </message>
     <message>
@@ -7068,7 +7068,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="71"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Descripción</translation>
     </message>
     <message>
@@ -7103,7 +7103,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="101"/>
-        <source>Modo grÃ¡fico:</source>
+        <source>Modo gráfico:</source>
         <translation>Modo gráfico:</translation>
     </message>
     <message>
@@ -7158,12 +7158,12 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="148"/>
-        <source>Mostras subtÃ­tulo</source>
+        <source>Mostras subtítulo</source>
         <translation>Mostras subtítulo</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="218"/>
-        <source>Velocidad de subtÃ­tulos:</source>
+        <source>Velocidad de subtítulos:</source>
         <translation>Velocidad de subtítulos:</translation>
     </message>
     <message>
@@ -7173,12 +7173,12 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="154"/>
-        <source>Filtro de grÃ¡ficos</source>
+        <source>Filtro de gráficos</source>
         <translation>Filtro de gráficos</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="157"/>
-        <source>CorrecciÃ³n de aspecto</source>
+        <source>Corrección de aspecto</source>
         <translation>Corrección de aspecto</translation>
     </message>
     <message>
@@ -7233,7 +7233,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="206"/>
-        <source>Volumen mÃºsica:</source>
+        <source>Volumen música:</source>
         <translation>Volumen música:</translation>
     </message>
     <message>
@@ -7248,7 +7248,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="215"/>
-        <source>Tiempo de la mÃºsica:</source>
+        <source>Tiempo de la música:</source>
         <translation>Tiempo de la música:</translation>
     </message>
     <message>
@@ -7318,7 +7318,7 @@ Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios ef
     <message>
         <location filename="../../src/grlida_info.cpp" line="73"/>
         <location filename="../../src/grlida_info.cpp" line="76"/>
-        <source>VersiÃ³n</source>
+        <source>Versión</source>
         <translation>Versión</translation>
     </message>
     <message>
@@ -7513,12 +7513,12 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>¿Eliminar...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation>¿Quieres eliminar la ISO/IMA/IMG de la lista?</translation>
     </message>
     <message>
@@ -7528,7 +7528,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Quieres eliminar de la lista?</source>
+        <source>¿Quieres eliminar de la lista?</source>
         <translation>¿Quieres eliminar de la lista?</translation>
     </message>
     <message>
@@ -7564,12 +7564,12 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="828"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>Se ha producido un error en el proceso, tiempo después de empezar con éxito</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="831"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>Se ha producido un error, waitFor...() Última función el tiempo de espera</translation>
     </message>
     <message>
@@ -7588,7 +7588,7 @@ Compruebe si lo tiene instalado.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">¿Quieres eliminar la ISO de la lista?</translation>
     </message>
     <message>
@@ -8042,7 +8042,7 @@ O el directorio de destino.</source>
     </message>
     <message>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="417"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Título</translation>
     </message>
     <message>
@@ -8058,7 +8058,7 @@ O el directorio de destino.</source>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="700"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1002"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1042"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Imágenes soportadas</translation>
     </message>
     <message>
@@ -9222,7 +9222,7 @@ O el directorio de destino.</source>
         <location filename="../../src/grlida_opciones.cpp" line="393"/>
         <location filename="../../src/grlida_opciones.cpp" line="500"/>
         <location filename="../../src/grlida_opciones.cpp" line="2437"/>
-        <source>ImÃ¡genes CategorÃ­as</source>
+        <source>Imágenes Categorías</source>
         <translation>Imágenes Categorí­as</translation>
     </message>
     <message>
@@ -9233,14 +9233,14 @@ O el directorio de destino.</source>
         <location filename="../../src/grlida_opciones.cpp" line="396"/>
         <location filename="../../src/grlida_opciones.cpp" line="503"/>
         <location filename="../../src/grlida_opciones.cpp" line="2439"/>
-        <source>ImÃ¡genes defecto</source>
+        <source>Imágenes defecto</source>
         <translation>Imágenes defecto</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="324"/>
         <location filename="../../src/grlida_opciones.cpp" line="350"/>
         <location filename="../../src/grlida_opciones.cpp" line="506"/>
-        <source>ImÃ¡genes idiomas</source>
+        <source>Imágenes idiomas</source>
         <translation>Imágenes idiomas</translation>
     </message>
     <message>
@@ -9265,53 +9265,53 @@ O el directorio de destino.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="880"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Compañia</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="888"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Año</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="889"/>
         <location filename="../../src/grlida_opciones.cpp" line="913"/>
         <location filename="../../src/grlida_opciones.cpp" line="932"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nº discos</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="891"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Gráficos</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="899"/>
         <location filename="../../src/grlida_opciones.cpp" line="916"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Calificación</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="906"/>
         <location filename="../../src/grlida_opciones.cpp" line="926"/>
         <location filename="../../src/grlida_opciones.cpp" line="2033"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Compañias</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="912"/>
         <location filename="../../src/grlida_opciones.cpp" line="2034"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Años</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="915"/>
-        <source>PuntuaciÃ³n</source>
+        <source>Puntuación</source>
         <translation>Puntuación</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="989"/>
-        <source>TÃ­tulo descriptivo</source>
+        <source>Título descriptivo</source>
         <translation>Tí­tulo descriptivo</translation>
     </message>
     <message>
@@ -9320,84 +9320,84 @@ O el directorio de destino.</source>
         <location filename="../../src/grlida_opciones.cpp" line="992"/>
         <location filename="../../src/grlida_opciones.cpp" line="993"/>
         <location filename="../../src/grlida_opciones.cpp" line="994"/>
-        <source>TÃ­tulo Juego</source>
+        <source>Título Juego</source>
         <translation>Tí­tulo Juego</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="999"/>
-        <source>El proxy se determina sobre la base de la aplicaciÃ³n</source>
+        <source>El proxy se determina sobre la base de la aplicación</source>
         <translation>El proxy se determina sobre la base de la aplicación</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1002"/>
-        <source>HTTP proxy sÃ³lo para las solicitudes</source>
+        <source>HTTP proxy sólo para las solicitudes</source>
         <translation>HTTP proxy sólo para las solicitudes</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1050"/>
         <location filename="../../src/grlida_opciones.cpp" line="1161"/>
-        <source>InformaciÃ³n sobre el formato de la fecha y hora</source>
+        <source>Información sobre el formato de la fecha y hora</source>
         <translation>Información sobre el formato de la fecha y hora</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1053"/>
-        <source>Lista bÃ¡sica de parÃ¡metros:</source>
+        <source>Lista básica de parámetros:</source>
         <translation>Lista básica de parámetros:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1057"/>
         <location filename="../../src/grlida_opciones.cpp" line="1106"/>
-        <source>ExpresiÃ³n</source>
+        <source>Expresión</source>
         <translation>Expresión</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1063"/>
-        <source>DÃ­a del mes sin ceros iniciales (1 a 31).</source>
+        <source>Día del mes sin ceros iniciales (1 a 31).</source>
         <translation>Dí­a del mes sin ceros iniciales (1 a 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1067"/>
-        <source>DÃ­a del mes, 2 dÃ­gitos con ceros iniciales (01 a 31).</source>
+        <source>Día del mes, 2 dígitos con ceros iniciales (01 a 31).</source>
         <translation>Dí­a del mes, 2 dí­gitos con ceros iniciales (01 a 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1071"/>
-        <source>Una representaciÃ³n textual de un dÃ­a, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
+        <source>Una representación textual de un día, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
         <translation>Una representación textual de un dí­a, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1075"/>
-        <source>Una representaciÃ³n textual completa del dÃ­a de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
+        <source>Una representación textual completa del día de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
         <translation>Una representación textual completa del día de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1079"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, sin ceros iniciales (1-12).</source>
+        <source>Representación numérica de un mes, sin ceros iniciales (1-12).</source>
         <translation>Representación numérica de un mes, sin ceros iniciales (1-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1083"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, con ceros iniciales (01-12).</source>
+        <source>Representación numérica de un mes, con ceros iniciales (01-12).</source>
         <translation>Representación numérica de un mes, con ceros iniciales (01-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1087"/>
-        <source>Una representaciÃ³n textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
+        <source>Una representación textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
         <translation>Una representación textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1091"/>
-        <source>Una representaciÃ³n textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
+        <source>Una representación textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
         <translation>Una representación textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1095"/>
-        <source>Una representaciÃ³n de dos dÃ­gitos de un aÃ±o (00-99).</source>
+        <source>Una representación de dos dígitos de un año (00-99).</source>
         <translation>Una representación de dos dí­gitos de un año (00-99).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1099"/>
-        <source>Una representaciÃ³n numÃ©rica completa de un aÃ±o, 4 dÃ­gitos.</source>
+        <source>Una representación numérica completa de un año, 4 dígitos.</source>
         <translation>Una representación numérica completa de un año, 4 dí­gitos.</translation>
     </message>
     <message>
@@ -9500,7 +9500,7 @@ O el directorio de destino.</source>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1200"/>
         <location filename="../../src/grlida_opciones.cpp" line="1463"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation>Debes poner un tí­tulo.</translation>
     </message>
     <message>
@@ -9520,12 +9520,12 @@ O el directorio de destino.</source>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>¿Eliminar...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1410"/>
-        <source>Â¿Deseas realmente eliminar este DOSBox de la lista?</source>
+        <source>¿Deseas realmente eliminar este DOSBox de la lista?</source>
         <translation>¿Deseas realmente eliminar este DOSBox de la lista?</translation>
     </message>
     <message>
@@ -9535,94 +9535,94 @@ O el directorio de destino.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1601"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation>¿Deseas realmente eliminar este emulador de la lista?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1672"/>
-        <source>Debes poner el nombre de la tabla para la nueva categorÃ­a.</source>
+        <source>Debes poner el nombre de la tabla para la nueva categoría.</source>
         <translation>Debes poner el nombre de la tabla para la nueva categorí­a.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1676"/>
-        <source>Debes poner el tÃ­tulo de la nueva categorÃ­a.</source>
-        <translation>Debes poner el tÃ­tulo de la nueva categoría.</translation>
+        <source>Debes poner el título de la nueva categoría.</source>
+        <translation>Debes poner el título de la nueva categoría.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1687"/>
         <location filename="../../src/grlida_opciones.cpp" line="1700"/>
-        <source>Â¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
+        <source>¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
         <translation>¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1721"/>
-        <source>No se ha podido aÃ±adir la nueva categorÃ­a.</source>
+        <source>No se ha podido añadir la nueva categoría.</source>
         <translation>No se ha podido añadir la nueva categorí­a.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1733"/>
-        <source>No se ha podido actualizar la categorÃ­a.</source>
+        <source>No se ha podido actualizar la categoría.</source>
         <translation>No se ha podido actualizar la categorí­a.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1843"/>
-        <source>Por favor selecciona una categorÃ­a de la lista para eliminarla</source>
+        <source>Por favor selecciona una categoría de la lista para eliminarla</source>
         <translation>Por favor selecciona una categorí­a de la lista para eliminarla</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1846"/>
-        <source>No se puede eliminar la tabla de la categorÃ­a.</source>
+        <source>No se puede eliminar la tabla de la categoría.</source>
         <translation>No se puede eliminar la tabla de la categorí­a.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1848"/>
-        <source>Â¿Deseas realmente eliminar esta categorÃ­a de la base de datos?</source>
+        <source>¿Deseas realmente eliminar esta categoría de la base de datos?</source>
         <translation>¿Deseas realmente eliminar esta categorí­a de la base de datos?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2021"/>
-        <source>Â¿Deseas restaurar el menÃº de navegaciÃ³n por defecto?</source>
+        <source>¿Deseas restaurar el menú de navegación por defecto?</source>
         <translation>¿Deseas restaurar el menú de navegación por defecto?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2050"/>
-        <source>Por favor selecciona un menÃº nav de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú nav de la lista para eliminarlo</source>
         <translation>Por favor selecciona un menú nav de la lista para eliminarlo</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2052"/>
-        <source>Â¿Deseas realmente eliminar este menÃº nav de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú nav de la base de datos?</source>
         <translation>¿Deseas realmente eliminar este menú nav de la base de datos?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2223"/>
-        <source>Â¿Deseas restaurar el menÃº de shortcut por defecto?</source>
+        <source>¿Deseas restaurar el menú de shortcut por defecto?</source>
         <translation>¿Deseas restaurar el menú de shortcut por defecto?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2256"/>
-        <source>Por favor selecciona un menÃº shortcut de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú shortcut de la lista para eliminarlo</source>
         <translation>Por favor selecciona un menú shortcut de la lista para eliminarlo</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2258"/>
-        <source>Â¿Deseas realmente eliminar este menÃº shortcut de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú shortcut de la base de datos?</source>
         <translation>¿Deseas realmente eliminar este menú shortcut de la base de datos?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2449"/>
         <location filename="../../src/grlida_opciones.cpp" line="2517"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Título</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2602"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Imágenes soportadas</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2628"/>
-        <source>Â¿Deseas realmente eliminar este dato de la lista?</source>
+        <source>¿Deseas realmente eliminar este dato de la lista?</source>
         <translation>¿Deseas realmente eliminar este dato de la lista?</translation>
     </message>
     <message>
@@ -9634,7 +9634,7 @@ O el directorio de destino.</source>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <source>¿Deseas eliminar la extensión?</source>
         <translation>¿Deseas eliminar la extensión?</translation>
     </message>
     <message>
@@ -10201,12 +10201,12 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="532"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Debes poner por lo menos el tí­tulo.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="573"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Debes poner un tí­tulo al juego</translation>
     </message>
     <message>
@@ -10229,22 +10229,22 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation>¿Usar montajes?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation>¿Deseas añadir los montajes usados?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>¿Eliminar montaje...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>¿Deseas eliminar este montaje?</translation>
     </message>
     <message>
@@ -10489,12 +10489,12 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="375"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Debes poner por lo menos el tí­tulo.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="415"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Debes poner un tí­tulo al juego</translation>
     </message>
     <message>
@@ -10578,7 +10578,7 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_vdmsound.cpp" line="268"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Debes poner por lo menos el tí­tulo.</translation>
     </message>
     <message>

--- a/res/idiomas/gr-lida_fr_FR.ts
+++ b/res/idiomas/gr-lida_fr_FR.ts
@@ -101,32 +101,32 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="359"/>
-        <source>SuperÃ­ndice</source>
+        <source>Superíndice</source>
         <translation>Exposant</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="362"/>
-        <source>SubÃ­ndice</source>
+        <source>Subíndice</source>
         <translation>Sous-indice</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="396"/>
-        <source>CÃ³digo</source>
+        <source>Código</source>
         <translation>Code</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="433"/>
-        <source>Coincidir mayÃºsculas/minÃºsculas</source>
+        <source>Coincidir mayúsculas/minúsculas</source>
         <translation>Coïnciders majuscules/minuscules</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1125"/>
-        <source>ImÃ¡genes</source>
+        <source>Imágenes</source>
         <translation>Images</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1130"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Images supportées</translation>
     </message>
     <message>
@@ -242,12 +242,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿Sobrescribir?</source>
+        <source>¿Sobrescribir?</source>
         <translation>Écraser?</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿El archivo &apos;</source>
+        <source>¿El archivo &apos;</source>
         <translation>Le fichier &apos;</translation>
     </message>
     <message>
@@ -257,7 +257,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1004"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Couverture (devant)</translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1006"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Note</translation>
     </message>
     <message>
@@ -282,7 +282,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1009"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Soustitre</translation>
     </message>
     <message>
@@ -362,12 +362,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1024"/>
-        <source>AÃ±adido el</source>
+        <source>Añadido el</source>
         <translation>Ajouté le</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1025"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphismes</translation>
     </message>
     <message>
@@ -397,7 +397,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1031"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
@@ -407,17 +407,17 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1033"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1037"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titre</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1038"/>
-        <source>TÃ­tulo album</source>
+        <source>Título album</source>
         <translation>Titre de l&apos;album</translation>
     </message>
     <message>
@@ -427,7 +427,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="2041"/>
-        <source>ConfiguraciÃ³n por defecto</source>
+        <source>Configuración por defecto</source>
         <translation>Configuration par défault</translation>
     </message>
     <message>
@@ -792,43 +792,43 @@
         <location filename="../../src/grdap.cpp" line="874"/>
         <location filename="../../src/grdap.cpp" line="880"/>
         <location filename="../../src/grdap.cpp" line="949"/>
-        <source>Âº</source>
+        <source>º</source>
         <translation>º</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="443"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Taille</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="495"/>
         <location filename="../../src/grdap.cpp" line="530"/>
-        <source>Seleccione la configuraciÃ³n que quieres abrir.</source>
+        <source>Seleccione la configuración que quieres abrir.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="587"/>
-        <source>TÃ­tulo del juego</source>
+        <source>Título del juego</source>
         <translation>Titre du jeu</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="590"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="725"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Page</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="799"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Roulette de protection</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="800"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Images supportées</translation>
     </message>
     <message>
@@ -2027,8 +2027,8 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="376"/>
-        <source>No se ha podido establecer una conexiÃ³n con la base de datos.
-Esta aplicaciÃ³n necesita soporte de SQLite. Mira la documentaciÃ³n de Qt SQL driver para mÃ¡s informaciÃ³n.
+        <source>No se ha podido establecer una conexión con la base de datos.
+Esta aplicación necesita soporte de SQLite. Mira la documentación de Qt SQL driver para más información.
 
 Click cancelar para salir.</source>
         <translation>La connection à la base de données n&apos;a pas pu se faire.
@@ -2039,30 +2039,30 @@ Appuyer sur Annuler pour quitter.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1653"/>
         <location filename="../../src/grlida.cpp" line="2094"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titre</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1656"/>
         <location filename="../../src/grlida.cpp" line="2097"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Editeur</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1661"/>
         <location filename="../../src/grlida.cpp" line="2105"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Année</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1662"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1664"/>
         <location filename="../../src/grlida.cpp" line="2109"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphismes</translation>
     </message>
     <message>
@@ -2072,7 +2072,7 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2108"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Taille</translation>
     </message>
     <message>
@@ -2084,12 +2084,12 @@ Appuyer sur Annuler pour quitter.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="2263"/>
         <location filename="../../src/grlida.cpp" line="2825"/>
-        <source>NÂº juegos</source>
+        <source>Nº juegos</source>
         <translation>Nº jeux</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1584"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information non disponible</translation>
     </message>
     <message>
@@ -2108,7 +2108,7 @@ Appuyer sur Annuler pour quitter.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1654"/>
         <location filename="../../src/grlida.cpp" line="2095"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Soustitre</translation>
     </message>
     <message>
@@ -2143,7 +2143,7 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2106"/>
-        <source>NÂº Discos</source>
+        <source>Nº Discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
@@ -2166,12 +2166,12 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3321"/>
-        <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3325"/>
-        <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
+        <source>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2181,17 +2181,17 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3341"/>
-        <source>Eliminar carÃ¡tula thumbs.</source>
+        <source>Eliminar carátula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3345"/>
-        <source>Eliminar imÃ¡genes de la caja.</source>
+        <source>Eliminar imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3350"/>
-        <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
+        <source>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2201,7 +2201,7 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3358"/>
-        <source>Eliminar imÃ¡genes.</source>
+        <source>Eliminar imágenes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2221,12 +2221,12 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3417"/>
-        <source>CarÃ¡tula</source>
+        <source>Carátula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3424"/>
-        <source>ImÃ¡genes de la caja.</source>
+        <source>Imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2236,7 +2236,7 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3443"/>
-        <source>ImÃ¡genes del juego</source>
+        <source>Imágenes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2246,17 +2246,17 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3477"/>
-        <source>ConfiguraciÃ³n de DOSBox</source>
+        <source>Configuración de DOSBox</source>
         <translation>Configurer DOSBox</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3495"/>
-        <source>ConfiguraciÃ³n de ScummVM</source>
+        <source>Configuración de ScummVM</source>
         <translation>Configuration de ScummVm</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3503"/>
-        <source>ConfiguraciÃ³n de VDMSound</source>
+        <source>Configuración de VDMSound</source>
         <translation>Configurer VDMSound</translation>
     </message>
     <message>
@@ -2292,12 +2292,12 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5112"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>Erreur dans le processus, temps après le démarrage réussi</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5115"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>Une erreur s&apos;est produite, waitFor...() dernière fonction du temps d&apos;attente</translation>
     </message>
     <message>
@@ -2323,7 +2323,7 @@ Appuyer sur Annuler pour quitter.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3313"/>
-        <source>Â¿Eliminar juego...?</source>
+        <source>¿Eliminar juego...?</source>
         <translation>Effacer le jeu?</translation>
     </message>
     <message>
@@ -2441,7 +2441,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="319"/>
-        <source>Â¿Redireccionar a &apos;%1&apos;?</source>
+        <source>¿Redireccionar a &apos;%1&apos;?</source>
         <translation>Rediriger vers %1?</translation>
     </message>
     <message>
@@ -2466,7 +2466,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="402"/>
-        <source>Uno o mÃ¡s errores de SSL se ha producido: %1</source>
+        <source>Uno o más errores de SSL se ha producido: %1</source>
         <translation>Une ou plusieurs erreurs SSL se sont produites: %1</translation>
     </message>
     <message>
@@ -2533,7 +2533,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="46"/>
-        <source>Cargando configuraciÃ³n...</source>
+        <source>Cargando configuración...</source>
         <translation>Teste configuration...</translation>
     </message>
     <message>
@@ -2661,12 +2661,12 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="882"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Editeur</translation>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="883"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Année</translation>
     </message>
     <message>
@@ -2684,12 +2684,12 @@ Please check the media service plugins are installed.</source>
     <name>frmAcercaD</name>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="68"/>
-        <source>es un lanzador comÃºn para los emuladores:</source>
+        <source>es un lanzador común para los emuladores:</source>
         <translation>est un launcher commun aux émulateurs:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="70"/>
-        <source>es GPL. Para mejorar el programa puedes dejar tu opiniÃ³n en</source>
+        <source>es GPL. Para mejorar el programa puedes dejar tu opinión en</source>
         <translation>est sous GPL. Pour améliorer le programme, tu peux laisser ton opinion sur</translation>
     </message>
     <message>
@@ -2832,22 +2832,22 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Effacer le montage...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Vraiment effacer ce point de montage?</translation>
     </message>
     <message>
@@ -4247,7 +4247,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="385"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2584"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Roulette de protection</translation>
     </message>
     <message>
@@ -4257,32 +4257,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="390"/>
-        <source>CarÃ¡tula delantera</source>
+        <source>Carátula delantera</source>
         <translation>Couverture (devant)</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="391"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Couverture (derrière)</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="392"/>
-        <source>CarÃ¡tula izquierda</source>
+        <source>Carátula izquierda</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="393"/>
-        <source>CarÃ¡tula derecha</source>
+        <source>Carátula derecha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="394"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="395"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4292,7 +4292,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="441"/>
-        <source>AÃ±adiendo un nuevo juego</source>
+        <source>Añadiendo un nuevo juego</source>
         <translation>Ajout d&apos;un nouveau jeu</translation>
     </message>
     <message>
@@ -4329,7 +4329,7 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1725"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1783"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1874"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Images supportées</translation>
     </message>
     <message>
@@ -4360,17 +4360,17 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Effacer...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1795"/>
-        <source>Â¿Deseas eliminar la imagen seleccionada?</source>
+        <source>¿Deseas eliminar la imagen seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
-        <source>Â¿Deseas eliminar la captura seleccionada?</source>
+        <source>¿Deseas eliminar la captura seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4380,7 +4380,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
-        <source>Â¿Deseas eliminar el video seleccionado?</source>
+        <source>¿Deseas eliminar el video seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4390,7 +4390,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Deseas eliminar el sonido seleccionado?</source>
+        <source>¿Deseas eliminar el sonido seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4404,7 +4404,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2096"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2194"/>
-        <source>Para aÃ±adir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
+        <source>Para añadir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4430,32 +4430,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Eliminar url...?</source>
+        <source>¿Eliminar url...?</source>
         <translation>Effacer l&apos;url...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Deseas eliminar esta url?</source>
+        <source>¿Deseas eliminar esta url?</source>
         <translation>Effacer cette URL?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Eliminar archivo...?</source>
+        <source>¿Eliminar archivo...?</source>
         <translation>Effacer le fichier...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Deseas eliminar este archivo?</source>
+        <source>¿Deseas eliminar este archivo?</source>
         <translation>Effacer ce fichier?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="86"/>
-        <source>Â¿Cerrar ventana?</source>
+        <source>¿Cerrar ventana?</source>
         <translation>Fermer la fenêtre?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="87"/>
-        <source>Â¿Deseas realmente cerrar la ventana?
+        <source>¿Deseas realmente cerrar la ventana?
 Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios efectuados.</source>
         <translation>Vraiment enlever le jeu de la base de données ?
 Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera également effacé.</translation>
@@ -4467,7 +4467,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1420"/>
-        <source>AÃ±adir grupo</source>
+        <source>Añadir grupo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4477,7 +4477,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1455"/>
-        <source>AÃ±adir</source>
+        <source>Añadir</source>
         <translation>Ajouter</translation>
     </message>
     <message>
@@ -4551,17 +4551,17 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
-        <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
+        <source>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</source>
         <translation>Forcer l&apos;utilisation de la couche ASPI. Fonctionne seulement sur Windows avec ASPI installé</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
-        <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
+        <source>Selección automática de la interfaz de audio de CD</source>
         <translation>Sélection automatique de l&apos;interface CD audio</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
-        <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
+        <source>Extracción digital de audio utilizado para los CD de audio</source>
         <translation>Extraction audio digitale pour les CD audio</translation>
     </message>
     <message>
@@ -4576,7 +4576,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
-        <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
+        <source>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</source>
         <translation>Forcer l&apos;utilisation de SDL pour le CD-ROM. Disponible pour tous les sytèmes</translation>
     </message>
     <message>
@@ -4596,16 +4596,16 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Effacer...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">Vraiment effacer l&apos;ISO de la liste?</translation>
     </message>
     <message>
@@ -5310,7 +5310,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="236"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation type="unfinished">Vous devez mettre un titre.</translation>
     </message>
     <message>
@@ -5356,12 +5356,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="361"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="390"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="386"/>
-        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuraciÃ³n.</source>
+        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5392,17 +5392,17 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="434"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="437"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Infos</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation type="unfinished">Effacer...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation type="unfinished">Voulez-vous vraiment supprimer cet émulateur de la liste?</translation>
     </message>
     <message>
@@ -5494,12 +5494,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="60"/>
-        <source>A la categorÃ­a</source>
+        <source>A la categoría</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="66"/>
-        <source>Selecciona la categorÃ­a de destino</source>
+        <source>Selecciona la categoría de destino</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5563,7 +5563,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_compatibilidad_exe.cpp" line="232"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Infos</translation>
     </message>
     <message>
@@ -5665,7 +5665,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="61"/>
-        <source>DiseÃ±ado y programado por</source>
+        <source>Diseñado y programado por</source>
         <translation>Design et programmation par</translation>
     </message>
     <message>
@@ -5690,7 +5690,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="62"/>
-        <source>Texto oculto en el manual del tipo Indiana Jones y la Ãltima Cruzada</source>
+        <source>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</source>
         <translation>Texte masqué dans le type manuel Indiana Jones and the Last Crusade</translation>
     </message>
 </context>
@@ -5723,12 +5723,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="76"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titre</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="80"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Soustitre</translation>
     </message>
     <message>
@@ -5783,7 +5783,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="145"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
@@ -5793,12 +5793,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="157"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Taille</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="162"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphismes</translation>
     </message>
     <message>
@@ -5842,32 +5842,32 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="187"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Couverture (devant)</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="192"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Couverture (derrière)</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="197"/>
-        <source>CarÃ¡tula lateral izquierdo</source>
+        <source>Carátula lateral izquierdo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="202"/>
-        <source>CarÃ¡tula lateral derecho</source>
+        <source>Carátula lateral derecho</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="207"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="212"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5897,7 +5897,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="239"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
@@ -6539,7 +6539,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_dosbox.cpp" line="660"/>
-        <source>Config - DespuÃ©s del exe</source>
+        <source>Config - Después del exe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6607,13 +6607,13 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <name>frmImportarJuego</name>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="164"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Infos</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="192"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1432"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Page</translation>
     </message>
     <message>
@@ -6635,12 +6635,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="260"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation type="unfinished">Titre</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="261"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation type="unfinished">Année</translation>
     </message>
     <message>
@@ -6651,12 +6651,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="293"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="308"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="294"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation type="unfinished">Taille</translation>
     </message>
     <message>
@@ -6673,7 +6673,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="420"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="779"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information non disponible</translation>
     </message>
     <message>
@@ -6743,13 +6743,13 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="1851"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1872"/>
-        <source>AÃ±adiendo a la lista</source>
+        <source>Añadiendo a la lista</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="2776"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="2780"/>
-        <source>Importando imÃ¡genes, juego</source>
+        <source>Importando imágenes, juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7076,7 +7076,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="71"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Description</translation>
     </message>
     <message>
@@ -7111,7 +7111,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="101"/>
-        <source>Modo grÃ¡fico:</source>
+        <source>Modo gráfico:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7166,12 +7166,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="148"/>
-        <source>Mostras subtÃ­tulo</source>
+        <source>Mostras subtítulo</source>
         <translation>Afficher les soustitres</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="218"/>
-        <source>Velocidad de subtÃ­tulos:</source>
+        <source>Velocidad de subtítulos:</source>
         <translation>Vitesse des sous-titres:</translation>
     </message>
     <message>
@@ -7181,12 +7181,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="154"/>
-        <source>Filtro de grÃ¡ficos</source>
+        <source>Filtro de gráficos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="157"/>
-        <source>CorrecciÃ³n de aspecto</source>
+        <source>Corrección de aspecto</source>
         <translation>Correction d&apos;aspect</translation>
     </message>
     <message>
@@ -7241,7 +7241,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="206"/>
-        <source>Volumen mÃºsica:</source>
+        <source>Volumen música:</source>
         <translation>Volume musique:</translation>
     </message>
     <message>
@@ -7256,7 +7256,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="215"/>
-        <source>Tiempo de la mÃºsica:</source>
+        <source>Tiempo de la música:</source>
         <translation>Tempo de la musique:</translation>
     </message>
     <message>
@@ -7305,7 +7305,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <message>
         <location filename="../../src/grlida_info.cpp" line="73"/>
         <location filename="../../src/grlida_info.cpp" line="76"/>
-        <source>VersiÃ³n</source>
+        <source>Versión</source>
         <translation>Version</translation>
     </message>
     <message>
@@ -7425,12 +7425,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Effacer...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7440,7 +7440,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Quieres eliminar de la lista?</source>
+        <source>¿Quieres eliminar de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7476,12 +7476,12 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="828"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation type="unfinished">Erreur dans le processus, temps après le démarrage réussi</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="831"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation type="unfinished">Une erreur s&apos;est produite, waitFor...() dernière fonction du temps d&apos;attente</translation>
     </message>
     <message>
@@ -7500,7 +7500,7 @@ Si c&apos;est un jeu DOSBox ou VDMSound, le fichier de configuration sera égale
         <translation type="unfinished">Une erreur inconnue s&apos;est produite</translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">Vraiment effacer l&apos;ISO de la liste?</translation>
     </message>
     <message>
@@ -8056,7 +8056,7 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="417"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titre</translation>
     </message>
     <message>
@@ -8072,7 +8072,7 @@ Vérifier l&apos;installation.</translation>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="700"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1002"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1042"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Images supportées</translation>
     </message>
     <message>
@@ -8106,7 +8106,7 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="915"/>
-        <source>PuntuaciÃ³n</source>
+        <source>Puntuación</source>
         <translation>Score</translation>
     </message>
     <message>
@@ -8126,52 +8126,52 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1063"/>
-        <source>DÃ­a del mes sin ceros iniciales (1 a 31).</source>
+        <source>Día del mes sin ceros iniciales (1 a 31).</source>
         <translation>Jour du mois sans zéro initial (1-31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1067"/>
-        <source>DÃ­a del mes, 2 dÃ­gitos con ceros iniciales (01 a 31).</source>
+        <source>Día del mes, 2 dígitos con ceros iniciales (01 a 31).</source>
         <translation>Jour du mois, affichage sur 2 chiffres (01-31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1071"/>
-        <source>Una representaciÃ³n textual de un dÃ­a, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
+        <source>Una representación textual de un día, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
         <translation>Affichage textuel abrégé du jour de la semaine (ex. &apos;Lun&apos;-&apos;Dim&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1075"/>
-        <source>Una representaciÃ³n textual completa del dÃ­a de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
+        <source>Una representación textual completa del día de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
         <translation>Affichage textuel complet du jour de la semaine (ex. &apos;Lundi&apos;-&apos;Dimanche&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1079"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, sin ceros iniciales (1-12).</source>
+        <source>Representación numérica de un mes, sin ceros iniciales (1-12).</source>
         <translation>Affichage numérique du mois, sans zéro initial (1-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1083"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, con ceros iniciales (01-12).</source>
+        <source>Representación numérica de un mes, con ceros iniciales (01-12).</source>
         <translation>Affichage numérique du mois sur deux chiffres (01-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1087"/>
-        <source>Una representaciÃ³n textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
+        <source>Una representación textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
         <translation>Affichage textuel abrégé du mois (ex. &apos;Jan&apos;-&apos;Dec&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1091"/>
-        <source>Una representaciÃ³n textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
+        <source>Una representación textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
         <translation>Affichage textuel complet du mois (ex. &apos;Janvier&apos;-&apos;Décembre&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1095"/>
-        <source>Una representaciÃ³n de dos dÃ­gitos de un aÃ±o (00-99).</source>
+        <source>Una representación de dos dígitos de un año (00-99).</source>
         <translation>Affichage sur deux chiffres de l&apos;année (00-99).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1099"/>
-        <source>Una representaciÃ³n numÃ©rica completa de un aÃ±o, 4 dÃ­gitos.</source>
+        <source>Una representación numérica completa de un año, 4 dígitos.</source>
         <translation>Affichage complet de l&apos;année, sur 4 chiffres.</translation>
     </message>
     <message>
@@ -8200,12 +8200,12 @@ Vérifier l&apos;installation.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1200"/>
         <location filename="../../src/grlida_opciones.cpp" line="1463"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation>Vous devez mettre un titre.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1410"/>
-        <source>Â¿Deseas realmente eliminar este DOSBox de la lista?</source>
+        <source>¿Deseas realmente eliminar este DOSBox de la lista?</source>
         <translation>Voulez-vous vraiment supprimer ce DOSBox dans la liste?</translation>
     </message>
     <message>
@@ -8215,17 +8215,17 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1601"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation>Voulez-vous vraiment supprimer cet émulateur de la liste?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1672"/>
-        <source>Debes poner el nombre de la tabla para la nueva categorÃ­a.</source>
+        <source>Debes poner el nombre de la tabla para la nueva categoría.</source>
         <translation>Entrer un nom de table pour la nouvelle catégorie.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1676"/>
-        <source>Debes poner el tÃ­tulo de la nueva categorÃ­a.</source>
+        <source>Debes poner el título de la nueva categoría.</source>
         <translation>Entrer un nom pour la nouvelle catégorie.</translation>
     </message>
     <message>
@@ -8248,27 +8248,27 @@ Vérifier l&apos;installation.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1687"/>
         <location filename="../../src/grlida_opciones.cpp" line="1700"/>
-        <source>Â¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
+        <source>¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
         <translation>La table existe déjà, utiliser le nom suivant?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1721"/>
-        <source>No se ha podido aÃ±adir la nueva categorÃ­a.</source>
+        <source>No se ha podido añadir la nueva categoría.</source>
         <translation>La nouvelle catégorie n&apos;a pas pu être créée.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1733"/>
-        <source>No se ha podido actualizar la categorÃ­a.</source>
+        <source>No se ha podido actualizar la categoría.</source>
         <translation>La catégorie n&apos;a pas pu être mise à jour.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1843"/>
-        <source>Por favor selecciona una categorÃ­a de la lista para eliminarla</source>
+        <source>Por favor selecciona una categoría de la lista para eliminarla</source>
         <translation>Choisir une catégorie de la liste à effacer</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1846"/>
-        <source>No se puede eliminar la tabla de la categorÃ­a.</source>
+        <source>No se puede eliminar la tabla de la categoría.</source>
         <translation>La table de cette catégorie ne peut pas être effacée.</translation>
     </message>
     <message>
@@ -8283,42 +8283,42 @@ Vérifier l&apos;installation.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Effacer...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1848"/>
-        <source>Â¿Deseas realmente eliminar esta categorÃ­a de la base de datos?</source>
+        <source>¿Deseas realmente eliminar esta categoría de la base de datos?</source>
         <translation>Vraiment effacer cette catégorie de la base de données?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2021"/>
-        <source>Â¿Deseas restaurar el menÃº de navegaciÃ³n por defecto?</source>
+        <source>¿Deseas restaurar el menú de navegación por defecto?</source>
         <translation>Restaurer le menu de navigation par défaut?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2050"/>
-        <source>Por favor selecciona un menÃº nav de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú nav de la lista para eliminarlo</source>
         <translation>Choisir un menu de navigation dans la liste pour l&apos;effacer</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2052"/>
-        <source>Â¿Deseas realmente eliminar este menÃº nav de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú nav de la base de datos?</source>
         <translation>Vraiment effacer ce menu de la base de données?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2223"/>
-        <source>Â¿Deseas restaurar el menÃº de shortcut por defecto?</source>
+        <source>¿Deseas restaurar el menú de shortcut por defecto?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2256"/>
-        <source>Por favor selecciona un menÃº shortcut de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú shortcut de la lista para eliminarlo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2258"/>
-        <source>Â¿Deseas realmente eliminar este menÃº shortcut de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú shortcut de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8330,7 +8330,7 @@ Vérifier l&apos;installation.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2449"/>
         <location filename="../../src/grlida_opciones.cpp" line="2517"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Titre</translation>
     </message>
     <message>
@@ -8388,7 +8388,7 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="880"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Editeur</translation>
     </message>
     <message>
@@ -8429,14 +8429,14 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="888"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Année</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="889"/>
         <location filename="../../src/grlida_opciones.cpp" line="913"/>
         <location filename="../../src/grlida_opciones.cpp" line="932"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Nbre de Cds</translation>
     </message>
     <message>
@@ -8446,7 +8446,7 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="891"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Graphismes</translation>
     </message>
     <message>
@@ -8483,7 +8483,7 @@ Vérifier l&apos;installation.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="899"/>
         <location filename="../../src/grlida_opciones.cpp" line="916"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Note</translation>
     </message>
     <message>
@@ -8508,7 +8508,7 @@ Vérifier l&apos;installation.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="906"/>
         <location filename="../../src/grlida_opciones.cpp" line="926"/>
         <location filename="../../src/grlida_opciones.cpp" line="2033"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Editeur</translation>
     </message>
     <message>
@@ -8546,7 +8546,7 @@ Vérifier l&apos;installation.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="912"/>
         <location filename="../../src/grlida_opciones.cpp" line="2034"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Année</translation>
     </message>
     <message>
@@ -8631,12 +8631,12 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="999"/>
-        <source>El proxy se determina sobre la base de la aplicaciÃ³n</source>
+        <source>El proxy se determina sobre la base de la aplicación</source>
         <translation>Le proxy se détermine sur la base de l&apos;application</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1002"/>
-        <source>HTTP proxy sÃ³lo para las solicitudes</source>
+        <source>HTTP proxy sólo para las solicitudes</source>
         <translation>HTTP proxy seulement sur requếte</translation>
     </message>
     <message>
@@ -8683,7 +8683,7 @@ Vérifier l&apos;installation.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="393"/>
         <location filename="../../src/grlida_opciones.cpp" line="500"/>
         <location filename="../../src/grlida_opciones.cpp" line="2437"/>
-        <source>ImÃ¡genes CategorÃ­as</source>
+        <source>Imágenes Categorías</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8694,14 +8694,14 @@ Vérifier l&apos;installation.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="396"/>
         <location filename="../../src/grlida_opciones.cpp" line="503"/>
         <location filename="../../src/grlida_opciones.cpp" line="2439"/>
-        <source>ImÃ¡genes defecto</source>
+        <source>Imágenes defecto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="324"/>
         <location filename="../../src/grlida_opciones.cpp" line="350"/>
         <location filename="../../src/grlida_opciones.cpp" line="506"/>
-        <source>ImÃ¡genes idiomas</source>
+        <source>Imágenes idiomas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8726,7 +8726,7 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="989"/>
-        <source>TÃ­tulo descriptivo</source>
+        <source>Título descriptivo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8735,13 +8735,13 @@ Vérifier l&apos;installation.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="992"/>
         <location filename="../../src/grlida_opciones.cpp" line="993"/>
         <location filename="../../src/grlida_opciones.cpp" line="994"/>
-        <source>TÃ­tulo Juego</source>
+        <source>Título Juego</source>
         <translation>Titre jeu</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1050"/>
         <location filename="../../src/grlida_opciones.cpp" line="1161"/>
-        <source>InformaciÃ³n sobre el formato de la fecha y hora</source>
+        <source>Información sobre el formato de la fecha y hora</source>
         <translation>Information sur le format de la date et de l&apos;heure</translation>
     </message>
     <message>
@@ -8751,13 +8751,13 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1053"/>
-        <source>Lista bÃ¡sica de parÃ¡metros:</source>
+        <source>Lista básica de parámetros:</source>
         <translation>Liste basique des paramètres:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1057"/>
         <location filename="../../src/grlida_opciones.cpp" line="1106"/>
-        <source>ExpresiÃ³n</source>
+        <source>Expresión</source>
         <translation>Expression</translation>
     </message>
     <message>
@@ -8857,7 +8857,7 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2602"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Images supportées</translation>
     </message>
     <message>
@@ -8869,7 +8869,7 @@ Vérifier l&apos;installation.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <source>¿Deseas eliminar la extensión?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8889,7 +8889,7 @@ Vérifier l&apos;installation.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2628"/>
-        <source>Â¿Deseas realmente eliminar este dato de la lista?</source>
+        <source>¿Deseas realmente eliminar este dato de la lista?</source>
         <translation>Vraiment effacer cet élément de la base de données?</translation>
     </message>
     <message>
@@ -10218,12 +10218,12 @@ Appuyer sur entrée pour quitter l&apos;assistant
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="532"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Entrer un titre pour le jeu.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="573"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Entrer un titre pour le jeu</translation>
     </message>
     <message>
@@ -10246,22 +10246,22 @@ Appuyer sur entrée pour quitter l&apos;assistant
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation>Utiliser des montures?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation>Voulez-vous ajouter les montures utilisées?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Effacer le montage...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Vraiment effacer ce point de montage?</translation>
     </message>
     <message>
@@ -10509,12 +10509,12 @@ Appuyer sur entrée pour quitter l&apos;assistant
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="375"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Entrer un titre pour le jeu.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="415"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Entrer un titre pour le jeu</translation>
     </message>
     <message>
@@ -10598,7 +10598,7 @@ Appuyer sur entrée pour quitter l&apos;assistant
     </message>
     <message>
         <location filename="../../src/grlida_wizard_vdmsound.cpp" line="268"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Entrer un titre pour le jeu.</translation>
     </message>
     <message>

--- a/res/idiomas/gr-lida_hu_HU.ts
+++ b/res/idiomas/gr-lida_hu_HU.ts
@@ -101,32 +101,32 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="359"/>
-        <source>SuperÃ­ndice</source>
+        <source>Superíndice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="362"/>
-        <source>SubÃ­ndice</source>
+        <source>Subíndice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="396"/>
-        <source>CÃ³digo</source>
+        <source>Código</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="433"/>
-        <source>Coincidir mayÃºsculas/minÃºsculas</source>
+        <source>Coincidir mayúsculas/minúsculas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1125"/>
-        <source>ImÃ¡genes</source>
+        <source>Imágenes</source>
         <translation>képalkotás</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1130"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Támogatott képek</translation>
     </message>
     <message>
@@ -242,12 +242,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿Sobrescribir?</source>
+        <source>¿Sobrescribir?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿El archivo &apos;</source>
+        <source>¿El archivo &apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -257,7 +257,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1004"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Előlap</translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1006"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Értékelés</translation>
     </message>
     <message>
@@ -282,7 +282,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1009"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Alcím</translation>
     </message>
     <message>
@@ -362,12 +362,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1024"/>
-        <source>AÃ±adido el</source>
+        <source>Añadido el</source>
         <translation>Hozzáadva</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1025"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafika</translation>
     </message>
     <message>
@@ -397,7 +397,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1031"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Leírás</translation>
     </message>
     <message>
@@ -407,17 +407,17 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1033"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1037"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Cím</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1038"/>
-        <source>TÃ­tulo album</source>
+        <source>Título album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -427,7 +427,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="2041"/>
-        <source>ConfiguraciÃ³n por defecto</source>
+        <source>Configuración por defecto</source>
         <translation>Az alapértelmezett konfiguráció</translation>
     </message>
     <message>
@@ -792,43 +792,43 @@
         <location filename="../../src/grdap.cpp" line="874"/>
         <location filename="../../src/grdap.cpp" line="880"/>
         <location filename="../../src/grdap.cpp" line="949"/>
-        <source>Âº</source>
+        <source>º</source>
         <translation>º</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="443"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Méret</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="495"/>
         <location filename="../../src/grdap.cpp" line="530"/>
-        <source>Seleccione la configuraciÃ³n que quieres abrir.</source>
+        <source>Seleccione la configuración que quieres abrir.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="587"/>
-        <source>TÃ­tulo del juego</source>
+        <source>Título del juego</source>
         <translation>Game title</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="590"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Leírás</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="725"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Oldal</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="799"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Másolási védelem kerék</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="800"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Támogatott képek</translation>
     </message>
     <message>
@@ -2027,8 +2027,8 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="376"/>
-        <source>No se ha podido establecer una conexiÃ³n con la base de datos.
-Esta aplicaciÃ³n necesita soporte de SQLite. Mira la documentaciÃ³n de Qt SQL driver para mÃ¡s informaciÃ³n.
+        <source>No se ha podido establecer una conexión con la base de datos.
+Esta aplicación necesita soporte de SQLite. Mira la documentación de Qt SQL driver para más información.
 
 Click cancelar para salir.</source>
         <translation>Nem sikerült csatlakozni az adatbázishoz.
@@ -2039,30 +2039,30 @@ Kilépéshez kattincson a Mégse-re.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1653"/>
         <location filename="../../src/grlida.cpp" line="2094"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Cím</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1656"/>
         <location filename="../../src/grlida.cpp" line="2097"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Kiadó</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1661"/>
         <location filename="../../src/grlida.cpp" line="2105"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Év</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1662"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1664"/>
         <location filename="../../src/grlida.cpp" line="2109"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafika</translation>
     </message>
     <message>
@@ -2072,7 +2072,7 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2108"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Méret</translation>
     </message>
     <message>
@@ -2084,12 +2084,12 @@ Kilépéshez kattincson a Mégse-re.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="2263"/>
         <location filename="../../src/grlida.cpp" line="2825"/>
-        <source>NÂº juegos</source>
+        <source>Nº juegos</source>
         <translation>Játékok száma</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1584"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Információ nem áll rendelkezésre</translation>
     </message>
     <message>
@@ -2108,7 +2108,7 @@ Kilépéshez kattincson a Mégse-re.</translation>
     <message>
         <location filename="../../src/grlida.cpp" line="1654"/>
         <location filename="../../src/grlida.cpp" line="2095"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Alcím</translation>
     </message>
     <message>
@@ -2143,7 +2143,7 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2106"/>
-        <source>NÂº Discos</source>
+        <source>Nº Discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
@@ -2166,12 +2166,12 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3321"/>
-        <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3325"/>
-        <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
+        <source>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2181,17 +2181,17 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3341"/>
-        <source>Eliminar carÃ¡tula thumbs.</source>
+        <source>Eliminar carátula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3345"/>
-        <source>Eliminar imÃ¡genes de la caja.</source>
+        <source>Eliminar imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3350"/>
-        <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
+        <source>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2201,7 +2201,7 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3358"/>
-        <source>Eliminar imÃ¡genes.</source>
+        <source>Eliminar imágenes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2221,12 +2221,12 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3417"/>
-        <source>CarÃ¡tula</source>
+        <source>Carátula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3424"/>
-        <source>ImÃ¡genes de la caja.</source>
+        <source>Imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2236,7 +2236,7 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3443"/>
-        <source>ImÃ¡genes del juego</source>
+        <source>Imágenes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2246,17 +2246,17 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3477"/>
-        <source>ConfiguraciÃ³n de DOSBox</source>
+        <source>Configuración de DOSBox</source>
         <translation>DOSBox konfiguráció</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3495"/>
-        <source>ConfiguraciÃ³n de ScummVM</source>
+        <source>Configuración de ScummVM</source>
         <translation>ScummVM konfiguráció</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3503"/>
-        <source>ConfiguraciÃ³n de VDMSound</source>
+        <source>Configuración de VDMSound</source>
         <translation>VDMSound konfiguráció</translation>
     </message>
     <message>
@@ -2292,12 +2292,12 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5112"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>Hiba történt a folyamat, miután sikeresen megkezdése</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5115"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>Hiba történt waitfor ... () Legutóbb out funkció</translation>
     </message>
     <message>
@@ -2323,7 +2323,7 @@ Kilépéshez kattincson a Mégse-re.</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3313"/>
-        <source>Â¿Eliminar juego...?</source>
+        <source>¿Eliminar juego...?</source>
         <translation>Játék törlése...?</translation>
     </message>
     <message>
@@ -2441,7 +2441,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="319"/>
-        <source>Â¿Redireccionar a &apos;%1&apos;?</source>
+        <source>¿Redireccionar a &apos;%1&apos;?</source>
         <translation>Átirányítás &apos;%1&apos;?</translation>
     </message>
     <message>
@@ -2466,7 +2466,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="402"/>
-        <source>Uno o mÃ¡s errores de SSL se ha producido: %1</source>
+        <source>Uno o más errores de SSL se ha producido: %1</source>
         <translation>Egy vagy több SSL könyvtár található: %1</translation>
     </message>
     <message>
@@ -2533,7 +2533,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="46"/>
-        <source>Cargando configuraciÃ³n...</source>
+        <source>Cargando configuración...</source>
         <translation>Konfiguráció betöltése...</translation>
     </message>
     <message>
@@ -2661,12 +2661,12 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="882"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Kiadó</translation>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="883"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Év</translation>
     </message>
     <message>
@@ -2684,12 +2684,12 @@ Please check the media service plugins are installed.</source>
     <name>frmAcercaD</name>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="68"/>
-        <source>es un lanzador comÃºn para los emuladores:</source>
+        <source>es un lanzador común para los emuladores:</source>
         <translation>egy közös indító a következő programoknak:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="70"/>
-        <source>es GPL. Para mejorar el programa puedes dejar tu opiniÃ³n en</source>
+        <source>es GPL. Para mejorar el programa puedes dejar tu opinión en</source>
         <translation>a GPL védi. Építő jellegű kritikát szívesen fogadunk</translation>
     </message>
     <message>
@@ -2832,22 +2832,22 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Törlés csatolás...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Szeretné e törölni ezt a csatolást?</translation>
     </message>
     <message>
@@ -4247,7 +4247,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="385"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2584"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Másolási védelem kerék</translation>
     </message>
     <message>
@@ -4257,32 +4257,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="390"/>
-        <source>CarÃ¡tula delantera</source>
+        <source>Carátula delantera</source>
         <translation>Előlap</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="391"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Hátlap</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="392"/>
-        <source>CarÃ¡tula izquierda</source>
+        <source>Carátula izquierda</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="393"/>
-        <source>CarÃ¡tula derecha</source>
+        <source>Carátula derecha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="394"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="395"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4292,7 +4292,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="441"/>
-        <source>AÃ±adiendo un nuevo juego</source>
+        <source>Añadiendo un nuevo juego</source>
         <translation>Új játék hozzáadása</translation>
     </message>
     <message>
@@ -4329,7 +4329,7 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1725"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1783"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1874"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Támogatott képek</translation>
     </message>
     <message>
@@ -4360,17 +4360,17 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Törlés...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1795"/>
-        <source>Â¿Deseas eliminar la imagen seleccionada?</source>
+        <source>¿Deseas eliminar la imagen seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
-        <source>Â¿Deseas eliminar la captura seleccionada?</source>
+        <source>¿Deseas eliminar la captura seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4380,7 +4380,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
-        <source>Â¿Deseas eliminar el video seleccionado?</source>
+        <source>¿Deseas eliminar el video seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4390,7 +4390,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Deseas eliminar el sonido seleccionado?</source>
+        <source>¿Deseas eliminar el sonido seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4404,7 +4404,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2096"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2194"/>
-        <source>Para aÃ±adir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
+        <source>Para añadir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4430,32 +4430,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Eliminar url...?</source>
+        <source>¿Eliminar url...?</source>
         <translation>Hivatkozás törlése?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Deseas eliminar esta url?</source>
+        <source>¿Deseas eliminar esta url?</source>
         <translation>Akarja törölni ezt a hivatkozást?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Eliminar archivo...?</source>
+        <source>¿Eliminar archivo...?</source>
         <translation>Fájl törlése...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Deseas eliminar este archivo?</source>
+        <source>¿Deseas eliminar este archivo?</source>
         <translation>Tényleg akarja törölni ezt a fájlt?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="86"/>
-        <source>Â¿Cerrar ventana?</source>
+        <source>¿Cerrar ventana?</source>
         <translation>Close window?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="87"/>
-        <source>Â¿Deseas realmente cerrar la ventana?
+        <source>¿Deseas realmente cerrar la ventana?
 Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios efectuados.</source>
         <translation>Do you really wish to close this window?
 Unsaved data / changes will be lost.</translation>
@@ -4467,7 +4467,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1420"/>
-        <source>AÃ±adir grupo</source>
+        <source>Añadir grupo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4477,7 +4477,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1455"/>
-        <source>AÃ±adir</source>
+        <source>Añadir</source>
         <translation>Hozzáadás</translation>
     </message>
     <message>
@@ -4551,17 +4551,17 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
-        <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
+        <source>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</source>
         <translation>Force ASPI layer usage. Only Windows with ASPI-Layer</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
-        <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
+        <source>Selección automática de la interfaz de audio de CD</source>
         <translation>Automatic Audio CD interface</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
-        <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
+        <source>Extracción digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio extraction for Audio CD</translation>
     </message>
     <message>
@@ -4576,7 +4576,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
-        <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
+        <source>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</source>
         <translation>Force SDL for CD-ROM. Available in all systems</translation>
     </message>
     <message>
@@ -4596,16 +4596,16 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Törlés...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">Szeretné törölni az ISO képfájlt a listaból?</translation>
     </message>
     <message>
@@ -5310,7 +5310,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="236"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5356,12 +5356,12 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="361"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="390"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Leírás</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="386"/>
-        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuraciÃ³n.</source>
+        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5392,17 +5392,17 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="434"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="437"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Információ</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation type="unfinished">Törlés...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5494,12 +5494,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="60"/>
-        <source>A la categorÃ­a</source>
+        <source>A la categoría</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="66"/>
-        <source>Selecciona la categorÃ­a de destino</source>
+        <source>Selecciona la categoría de destino</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5563,7 +5563,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_compatibilidad_exe.cpp" line="232"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Információ</translation>
     </message>
     <message>
@@ -5665,7 +5665,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="61"/>
-        <source>DiseÃ±ado y programado por</source>
+        <source>Diseñado y programado por</source>
         <translation>Tervezte és fejlesztette</translation>
     </message>
     <message>
@@ -5690,7 +5690,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="62"/>
-        <source>Texto oculto en el manual del tipo Indiana Jones y la Ãltima Cruzada</source>
+        <source>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</source>
         <translation>Rejtett szöveg a típusú kézikönyvben Indiana Jones and the Last Crusade</translation>
     </message>
 </context>
@@ -5723,12 +5723,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="76"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Cím</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="80"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Alcím</translation>
     </message>
     <message>
@@ -5783,7 +5783,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="145"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
@@ -5793,12 +5793,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="157"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Méret</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="162"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafika</translation>
     </message>
     <message>
@@ -5842,32 +5842,32 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="187"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Előlap</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="192"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Hátlap</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="197"/>
-        <source>CarÃ¡tula lateral izquierdo</source>
+        <source>Carátula lateral izquierdo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="202"/>
-        <source>CarÃ¡tula lateral derecho</source>
+        <source>Carátula lateral derecho</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="207"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="212"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5897,7 +5897,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="239"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Leírás</translation>
     </message>
     <message>
@@ -6539,7 +6539,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_dosbox.cpp" line="660"/>
-        <source>Config - DespuÃ©s del exe</source>
+        <source>Config - Después del exe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6607,13 +6607,13 @@ Unsaved data / changes will be lost.</translation>
     <name>frmImportarJuego</name>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="164"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Információ</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="192"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1432"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Oldal</translation>
     </message>
     <message>
@@ -6635,12 +6635,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="260"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation type="unfinished">Cím</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="261"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation type="unfinished">Év</translation>
     </message>
     <message>
@@ -6651,12 +6651,12 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="293"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="308"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Leírás</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="294"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation type="unfinished">Méret</translation>
     </message>
     <message>
@@ -6673,7 +6673,7 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="420"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="779"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Információ nem áll rendelkezésre</translation>
     </message>
     <message>
@@ -6743,13 +6743,13 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="1851"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1872"/>
-        <source>AÃ±adiendo a la lista</source>
+        <source>Añadiendo a la lista</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="2776"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="2780"/>
-        <source>Importando imÃ¡genes, juego</source>
+        <source>Importando imágenes, juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7076,7 +7076,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="71"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Leírás</translation>
     </message>
     <message>
@@ -7111,7 +7111,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="101"/>
-        <source>Modo grÃ¡fico:</source>
+        <source>Modo gráfico:</source>
         <translation>Grafikai mód:</translation>
     </message>
     <message>
@@ -7166,12 +7166,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="148"/>
-        <source>Mostras subtÃ­tulo</source>
+        <source>Mostras subtítulo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="218"/>
-        <source>Velocidad de subtÃ­tulos:</source>
+        <source>Velocidad de subtítulos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7181,12 +7181,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="154"/>
-        <source>Filtro de grÃ¡ficos</source>
+        <source>Filtro de gráficos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="157"/>
-        <source>CorrecciÃ³n de aspecto</source>
+        <source>Corrección de aspecto</source>
         <translation>Aspect korrekció</translation>
     </message>
     <message>
@@ -7241,7 +7241,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="206"/>
-        <source>Volumen mÃºsica:</source>
+        <source>Volumen música:</source>
         <translation>Zene hangerő:</translation>
     </message>
     <message>
@@ -7256,7 +7256,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="215"/>
-        <source>Tiempo de la mÃºsica:</source>
+        <source>Tiempo de la música:</source>
         <translation>Zene tempó:</translation>
     </message>
     <message>
@@ -7305,7 +7305,7 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_info.cpp" line="73"/>
         <location filename="../../src/grlida_info.cpp" line="76"/>
-        <source>VersiÃ³n</source>
+        <source>Versión</source>
         <translation>Verzió</translation>
     </message>
     <message>
@@ -7425,12 +7425,12 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Törlés...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7440,7 +7440,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Quieres eliminar de la lista?</source>
+        <source>¿Quieres eliminar de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7476,12 +7476,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="828"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation type="unfinished">Hiba történt a folyamat, miután sikeresen megkezdése</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="831"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation type="unfinished">Hiba történt waitfor ... () Legutóbb out funkció</translation>
     </message>
     <message>
@@ -7500,7 +7500,7 @@ Unsaved data / changes will be lost.</translation>
         <translation type="unfinished">Ismeretlen hiba történt</translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">Szeretné törölni az ISO képfájlt a listaból?</translation>
     </message>
     <message>
@@ -8056,7 +8056,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="417"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Cím</translation>
     </message>
     <message>
@@ -8072,7 +8072,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="700"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1002"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1042"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Támogatott képek</translation>
     </message>
     <message>
@@ -8106,7 +8106,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="915"/>
-        <source>PuntuaciÃ³n</source>
+        <source>Puntuación</source>
         <translation>Score</translation>
     </message>
     <message>
@@ -8126,52 +8126,52 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1063"/>
-        <source>DÃ­a del mes sin ceros iniciales (1 a 31).</source>
+        <source>Día del mes sin ceros iniciales (1 a 31).</source>
         <translation>A hónap napja nulla nélkül (1-től 31-ig).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1067"/>
-        <source>DÃ­a del mes, 2 dÃ­gitos con ceros iniciales (01 a 31).</source>
+        <source>Día del mes, 2 dígitos con ceros iniciales (01 a 31).</source>
         <translation>A hónap napja nullával (01-től 31-ig).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1071"/>
-        <source>Una representaciÃ³n textual de un dÃ­a, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
+        <source>Una representación textual de un día, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
         <translation>Rövidített hét napjai (pl. Hét-től Vas-ig).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1075"/>
-        <source>Una representaciÃ³n textual completa del dÃ­a de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
+        <source>Una representación textual completa del día de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
         <translation>Teljes hét napjai (pl. Hétfőtől Vasárnapig).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1079"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, sin ceros iniciales (1-12).</source>
+        <source>Representación numérica de un mes, sin ceros iniciales (1-12).</source>
         <translation>Hónap számozással nulla nélkül (1-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1083"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, con ceros iniciales (01-12).</source>
+        <source>Representación numérica de un mes, con ceros iniciales (01-12).</source>
         <translation>Hónap számozással nullával (01-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1087"/>
-        <source>Una representaciÃ³n textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
+        <source>Una representación textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
         <translation>Rövidített hónap nevek (pl. &apos;Jan&apos; to &apos;Dec&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1091"/>
-        <source>Una representaciÃ³n textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
+        <source>Una representación textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
         <translation>Hónap teljes neve (pl. &apos;Januártól&apos; to &apos;Decemberig&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1095"/>
-        <source>Una representaciÃ³n de dos dÃ­gitos de un aÃ±o (00-99).</source>
+        <source>Una representación de dos dígitos de un año (00-99).</source>
         <translation>Év két számjegyként (00-99).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1099"/>
-        <source>Una representaciÃ³n numÃ©rica completa de un aÃ±o, 4 dÃ­gitos.</source>
+        <source>Una representación numérica completa de un año, 4 dígitos.</source>
         <translation>Év négy számjegyként.</translation>
     </message>
     <message>
@@ -8200,12 +8200,12 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1200"/>
         <location filename="../../src/grlida_opciones.cpp" line="1463"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1410"/>
-        <source>Â¿Deseas realmente eliminar este DOSBox de la lista?</source>
+        <source>¿Deseas realmente eliminar este DOSBox de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8215,17 +8215,17 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1601"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1672"/>
-        <source>Debes poner el nombre de la tabla para la nueva categorÃ­a.</source>
+        <source>Debes poner el nombre de la tabla para la nueva categoría.</source>
         <translation>You must enter a table name for the new category.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1676"/>
-        <source>Debes poner el tÃ­tulo de la nueva categorÃ­a.</source>
+        <source>Debes poner el título de la nueva categoría.</source>
         <translation>You must enter the name of the new category.</translation>
     </message>
     <message>
@@ -8248,27 +8248,27 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1687"/>
         <location filename="../../src/grlida_opciones.cpp" line="1700"/>
-        <source>Â¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
+        <source>¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
         <translation>The table already exists. Do you want to use the following name for the table?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1721"/>
-        <source>No se ha podido aÃ±adir la nueva categorÃ­a.</source>
+        <source>No se ha podido añadir la nueva categoría.</source>
         <translation>Couldn&apos;t add the new category.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1733"/>
-        <source>No se ha podido actualizar la categorÃ­a.</source>
+        <source>No se ha podido actualizar la categoría.</source>
         <translation>Couldn&apos;t update the category.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1843"/>
-        <source>Por favor selecciona una categorÃ­a de la lista para eliminarla</source>
+        <source>Por favor selecciona una categoría de la lista para eliminarla</source>
         <translation>Please select a category from the list to delete</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1846"/>
-        <source>No se puede eliminar la tabla de la categorÃ­a.</source>
+        <source>No se puede eliminar la tabla de la categoría.</source>
         <translation>Can&apos;t delete this table from the category.</translation>
     </message>
     <message>
@@ -8283,42 +8283,42 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Törlés...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1848"/>
-        <source>Â¿Deseas realmente eliminar esta categorÃ­a de la base de datos?</source>
+        <source>¿Deseas realmente eliminar esta categoría de la base de datos?</source>
         <translation>Do you really wish to delete this category from the database?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2021"/>
-        <source>Â¿Deseas restaurar el menÃº de navegaciÃ³n por defecto?</source>
+        <source>¿Deseas restaurar el menú de navegación por defecto?</source>
         <translation>Do you wish to restore the default navigation menu?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2050"/>
-        <source>Por favor selecciona un menÃº nav de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú nav de la lista para eliminarlo</source>
         <translation>Please select a navigation menu from the list to delete</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2052"/>
-        <source>Â¿Deseas realmente eliminar este menÃº nav de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú nav de la base de datos?</source>
         <translation>Do you really wish to delete this navigation menu from the database?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2223"/>
-        <source>Â¿Deseas restaurar el menÃº de shortcut por defecto?</source>
+        <source>¿Deseas restaurar el menú de shortcut por defecto?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2256"/>
-        <source>Por favor selecciona un menÃº shortcut de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú shortcut de la lista para eliminarlo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2258"/>
-        <source>Â¿Deseas realmente eliminar este menÃº shortcut de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú shortcut de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8330,7 +8330,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2449"/>
         <location filename="../../src/grlida_opciones.cpp" line="2517"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Cím</translation>
     </message>
     <message>
@@ -8388,7 +8388,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="880"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Kiadó</translation>
     </message>
     <message>
@@ -8429,14 +8429,14 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="888"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Év</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="889"/>
         <location filename="../../src/grlida_opciones.cpp" line="913"/>
         <location filename="../../src/grlida_opciones.cpp" line="932"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Lemezek száma</translation>
     </message>
     <message>
@@ -8446,7 +8446,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="891"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Grafika</translation>
     </message>
     <message>
@@ -8483,7 +8483,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="899"/>
         <location filename="../../src/grlida_opciones.cpp" line="916"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Értékelés</translation>
     </message>
     <message>
@@ -8508,7 +8508,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="906"/>
         <location filename="../../src/grlida_opciones.cpp" line="926"/>
         <location filename="../../src/grlida_opciones.cpp" line="2033"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Kiadó</translation>
     </message>
     <message>
@@ -8546,7 +8546,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="912"/>
         <location filename="../../src/grlida_opciones.cpp" line="2034"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Év</translation>
     </message>
     <message>
@@ -8631,12 +8631,12 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="999"/>
-        <source>El proxy se determina sobre la base de la aplicaciÃ³n</source>
+        <source>El proxy se determina sobre la base de la aplicación</source>
         <translation>Proxy használata a proxy adatokra alapozva</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1002"/>
-        <source>HTTP proxy sÃ³lo para las solicitudes</source>
+        <source>HTTP proxy sólo para las solicitudes</source>
         <translation>Proxy-zás HTTP kérelem esetén csak</translation>
     </message>
     <message>
@@ -8683,7 +8683,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="393"/>
         <location filename="../../src/grlida_opciones.cpp" line="500"/>
         <location filename="../../src/grlida_opciones.cpp" line="2437"/>
-        <source>ImÃ¡genes CategorÃ­as</source>
+        <source>Imágenes Categorías</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8694,14 +8694,14 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="396"/>
         <location filename="../../src/grlida_opciones.cpp" line="503"/>
         <location filename="../../src/grlida_opciones.cpp" line="2439"/>
-        <source>ImÃ¡genes defecto</source>
+        <source>Imágenes defecto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="324"/>
         <location filename="../../src/grlida_opciones.cpp" line="350"/>
         <location filename="../../src/grlida_opciones.cpp" line="506"/>
-        <source>ImÃ¡genes idiomas</source>
+        <source>Imágenes idiomas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8726,7 +8726,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="989"/>
-        <source>TÃ­tulo descriptivo</source>
+        <source>Título descriptivo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8735,13 +8735,13 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="992"/>
         <location filename="../../src/grlida_opciones.cpp" line="993"/>
         <location filename="../../src/grlida_opciones.cpp" line="994"/>
-        <source>TÃ­tulo Juego</source>
+        <source>Título Juego</source>
         <translation>Game title</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1050"/>
         <location filename="../../src/grlida_opciones.cpp" line="1161"/>
-        <source>InformaciÃ³n sobre el formato de la fecha y hora</source>
+        <source>Información sobre el formato de la fecha y hora</source>
         <translation>Információ a dátumról és időformátumról</translation>
     </message>
     <message>
@@ -8751,13 +8751,13 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1053"/>
-        <source>Lista bÃ¡sica de parÃ¡metros:</source>
+        <source>Lista básica de parámetros:</source>
         <translation>Alapvető paraméter lista:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1057"/>
         <location filename="../../src/grlida_opciones.cpp" line="1106"/>
-        <source>ExpresiÃ³n</source>
+        <source>Expresión</source>
         <translation>Kifejezés</translation>
     </message>
     <message>
@@ -8857,7 +8857,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2602"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Támogatott képek</translation>
     </message>
     <message>
@@ -8869,7 +8869,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <source>¿Deseas eliminar la extensión?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8889,7 +8889,7 @@ Ellenőrizze,hogy a program fel e van telepítve.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2628"/>
-        <source>Â¿Deseas realmente eliminar este dato de la lista?</source>
+        <source>¿Deseas realmente eliminar este dato de la lista?</source>
         <translation>Do you really wish to delete this item from the list?</translation>
     </message>
     <message>
@@ -10218,12 +10218,12 @@ A varázsló bezárásához kattincson az OK-ra
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="532"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Meg kell határoznia legalább a címet.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="573"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Meg kell határoznia a játék címét</translation>
     </message>
     <message>
@@ -10246,22 +10246,22 @@ A varázsló bezárásához kattincson az OK-ra
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Törlés csatolás...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Szeretné e törölni ezt a csatolást?</translation>
     </message>
     <message>
@@ -10509,12 +10509,12 @@ A varázsló bezárásához kattincson az OK-ra
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="375"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Meg kell határoznia legalább a címet.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="415"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Meg kell határoznia a játék címét</translation>
     </message>
     <message>
@@ -10598,7 +10598,7 @@ A varázsló bezárásához kattincson az OK-ra
     </message>
     <message>
         <location filename="../../src/grlida_wizard_vdmsound.cpp" line="268"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Meg kell határoznia legalább a címet.</translation>
     </message>
     <message>

--- a/res/idiomas/gr-lida_ru_RU.ts
+++ b/res/idiomas/gr-lida_ru_RU.ts
@@ -101,32 +101,32 @@
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="359"/>
-        <source>SuperÃ­ndice</source>
+        <source>Superíndice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="362"/>
-        <source>SubÃ­ndice</source>
+        <source>Subíndice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="396"/>
-        <source>CÃ³digo</source>
+        <source>Código</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="433"/>
-        <source>Coincidir mayÃºsculas/minÃºsculas</source>
+        <source>Coincidir mayúsculas/minúsculas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1125"/>
-        <source>ImÃ¡genes</source>
+        <source>Imágenes</source>
         <translation>изображений</translation>
     </message>
     <message>
         <location filename="../../3rdparty/editorwidget/editorwidget.cpp" line="1130"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Поддерживаемые образы</translation>
     </message>
     <message>
@@ -242,12 +242,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿Sobrescribir?</source>
+        <source>¿Sobrescribir?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="620"/>
-        <source>Â¿El archivo &apos;</source>
+        <source>¿El archivo &apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -257,7 +257,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1004"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Передняя обложка</translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1006"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Рейтинг</translation>
     </message>
     <message>
@@ -282,7 +282,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1009"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Подзаголовок</translation>
     </message>
     <message>
@@ -362,12 +362,12 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1024"/>
-        <source>AÃ±adido el</source>
+        <source>Añadido el</source>
         <translation>Добалена</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1025"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Графика</translation>
     </message>
     <message>
@@ -397,7 +397,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1031"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Описание</translation>
     </message>
     <message>
@@ -407,17 +407,17 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1033"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1037"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Название</translation>
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="1038"/>
-        <source>TÃ­tulo album</source>
+        <source>Título album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -427,7 +427,7 @@
     </message>
     <message>
         <location filename="../../src/funciones.cpp" line="2041"/>
-        <source>ConfiguraciÃ³n por defecto</source>
+        <source>Configuración por defecto</source>
         <translation>Default configuration</translation>
     </message>
     <message>
@@ -792,43 +792,43 @@
         <location filename="../../src/grdap.cpp" line="874"/>
         <location filename="../../src/grdap.cpp" line="880"/>
         <location filename="../../src/grdap.cpp" line="949"/>
-        <source>Âº</source>
+        <source>º</source>
         <translation>º</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="443"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Размер</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="495"/>
         <location filename="../../src/grdap.cpp" line="530"/>
-        <source>Seleccione la configuraciÃ³n que quieres abrir.</source>
+        <source>Seleccione la configuración que quieres abrir.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="587"/>
-        <source>TÃ­tulo del juego</source>
+        <source>Título del juego</source>
         <translation>Game title</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="590"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Описание</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="725"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Страница</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="799"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Образ с защитой от копирования</translation>
     </message>
     <message>
         <location filename="../../src/grdap.cpp" line="800"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Поддерживаемые образы</translation>
     </message>
     <message>
@@ -2027,8 +2027,8 @@
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="376"/>
-        <source>No se ha podido establecer una conexiÃ³n con la base de datos.
-Esta aplicaciÃ³n necesita soporte de SQLite. Mira la documentaciÃ³n de Qt SQL driver para mÃ¡s informaciÃ³n.
+        <source>No se ha podido establecer una conexión con la base de datos.
+Esta aplicación necesita soporte de SQLite. Mira la documentación de Qt SQL driver para más información.
 
 Click cancelar para salir.</source>
         <translation>Не удается соединиться с базой данных.
@@ -2039,30 +2039,30 @@ Click cancelar para salir.</source>
     <message>
         <location filename="../../src/grlida.cpp" line="1653"/>
         <location filename="../../src/grlida.cpp" line="2094"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Название</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1656"/>
         <location filename="../../src/grlida.cpp" line="2097"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Компания</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1661"/>
         <location filename="../../src/grlida.cpp" line="2105"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Год</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1662"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1664"/>
         <location filename="../../src/grlida.cpp" line="2109"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Графика</translation>
     </message>
     <message>
@@ -2072,7 +2072,7 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2108"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Размер</translation>
     </message>
     <message>
@@ -2084,12 +2084,12 @@ Click cancelar para salir.</source>
     <message>
         <location filename="../../src/grlida.cpp" line="2263"/>
         <location filename="../../src/grlida.cpp" line="2825"/>
-        <source>NÂº juegos</source>
+        <source>Nº juegos</source>
         <translation>Количество игр</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="1584"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information not available</translation>
     </message>
     <message>
@@ -2108,7 +2108,7 @@ Click cancelar para salir.</source>
     <message>
         <location filename="../../src/grlida.cpp" line="1654"/>
         <location filename="../../src/grlida.cpp" line="2095"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Подзаголовок</translation>
     </message>
     <message>
@@ -2143,7 +2143,7 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="2106"/>
-        <source>NÂº Discos</source>
+        <source>Nº Discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
@@ -2166,12 +2166,12 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3321"/>
-        <source>Â¿Deseas realmente eliminar este juego de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este juego de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3325"/>
-        <source>Si es de DOSBox o VDMSound tambiÃ©n se borra el archivo de configuraciÃ³n.</source>
+        <source>Si es de DOSBox o VDMSound también se borra el archivo de configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2181,17 +2181,17 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3341"/>
-        <source>Eliminar carÃ¡tula thumbs.</source>
+        <source>Eliminar carátula thumbs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3345"/>
-        <source>Eliminar imÃ¡genes de la caja.</source>
+        <source>Eliminar imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3350"/>
-        <source>CarÃ¡tula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
+        <source>Carátula delantera, trasera, lateral izquierdo, derecho, arriba, abajo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2201,7 +2201,7 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3358"/>
-        <source>Eliminar imÃ¡genes.</source>
+        <source>Eliminar imágenes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2221,12 +2221,12 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3417"/>
-        <source>CarÃ¡tula</source>
+        <source>Carátula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3424"/>
-        <source>ImÃ¡genes de la caja.</source>
+        <source>Imágenes de la caja.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2236,7 +2236,7 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3443"/>
-        <source>ImÃ¡genes del juego</source>
+        <source>Imágenes del juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2246,17 +2246,17 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3477"/>
-        <source>ConfiguraciÃ³n de DOSBox</source>
+        <source>Configuración de DOSBox</source>
         <translation>Конфигурация DOSBox</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3495"/>
-        <source>ConfiguraciÃ³n de ScummVM</source>
+        <source>Configuración de ScummVM</source>
         <translation>Конфигурация ScummVM</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3503"/>
-        <source>ConfiguraciÃ³n de VDMSound</source>
+        <source>Configuración de VDMSound</source>
         <translation>Конфигурация VDMSound</translation>
     </message>
     <message>
@@ -2292,12 +2292,12 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5112"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation>There was an error in the process, time after starting successfully</translation>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="5115"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation>There was an error, waitFor...() Last time out function</translation>
     </message>
     <message>
@@ -2323,7 +2323,7 @@ Click cancelar para salir.</source>
     </message>
     <message>
         <location filename="../../src/grlida.cpp" line="3313"/>
-        <source>Â¿Eliminar juego...?</source>
+        <source>¿Eliminar juego...?</source>
         <translation>Удаление иры...?</translation>
     </message>
     <message>
@@ -2441,7 +2441,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="319"/>
-        <source>Â¿Redireccionar a &apos;%1&apos;?</source>
+        <source>¿Redireccionar a &apos;%1&apos;?</source>
         <translation>Redirect to %1?</translation>
     </message>
     <message>
@@ -2466,7 +2466,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/httpdownload.cpp" line="402"/>
-        <source>Uno o mÃ¡s errores de SSL se ha producido: %1</source>
+        <source>Uno o más errores de SSL se ha producido: %1</source>
         <translation>Произошла одна или более SSL ошибка: %1</translation>
     </message>
     <message>
@@ -2533,7 +2533,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="46"/>
-        <source>Cargando configuraciÃ³n...</source>
+        <source>Cargando configuración...</source>
         <translation>Загрузка конфигурации...</translation>
     </message>
     <message>
@@ -2661,12 +2661,12 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="882"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Компании</translation>
     </message>
     <message>
         <location filename="../../src/dbsql.cpp" line="883"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Год</translation>
     </message>
     <message>
@@ -2684,12 +2684,12 @@ Please check the media service plugins are installed.</source>
     <name>frmAcercaD</name>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="68"/>
-        <source>es un lanzador comÃºn para los emuladores:</source>
+        <source>es un lanzador común para los emuladores:</source>
         <translation>- это общее средство для запуска программ:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_acercad.cpp" line="70"/>
-        <source>es GPL. Para mejorar el programa puedes dejar tu opiniÃ³n en</source>
+        <source>es GPL. Para mejorar el programa puedes dejar tu opinión en</source>
         <translation>это GPL. Конструктивная критика приветствуется на</translation>
     </message>
     <message>
@@ -2832,22 +2832,22 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="898"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Delete mounting settings?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_dosbox.cpp" line="1055"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Вы действительно хотите удалить это монтирование?</translation>
     </message>
     <message>
@@ -4247,7 +4247,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="385"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2584"/>
-        <source>Ruleta de protecciÃ³n</source>
+        <source>Ruleta de protección</source>
         <translation>Образ с защитой от копирования</translation>
     </message>
     <message>
@@ -4257,32 +4257,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="390"/>
-        <source>CarÃ¡tula delantera</source>
+        <source>Carátula delantera</source>
         <translation>Фронтальная обложка</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="391"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Задняя обложка</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="392"/>
-        <source>CarÃ¡tula izquierda</source>
+        <source>Carátula izquierda</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="393"/>
-        <source>CarÃ¡tula derecha</source>
+        <source>Carátula derecha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="394"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="395"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4292,7 +4292,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="441"/>
-        <source>AÃ±adiendo un nuevo juego</source>
+        <source>Añadiendo un nuevo juego</source>
         <translation>Добавление новой игры</translation>
     </message>
     <message>
@@ -4329,7 +4329,7 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1725"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1783"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1874"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Поддерживаемые образы</translation>
     </message>
     <message>
@@ -4360,17 +4360,17 @@ Please check the media service plugins are installed.</source>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Удалить...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1795"/>
-        <source>Â¿Deseas eliminar la imagen seleccionada?</source>
+        <source>¿Deseas eliminar la imagen seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1887"/>
-        <source>Â¿Deseas eliminar la captura seleccionada?</source>
+        <source>¿Deseas eliminar la captura seleccionada?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4380,7 +4380,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1949"/>
-        <source>Â¿Deseas eliminar el video seleccionado?</source>
+        <source>¿Deseas eliminar el video seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4390,7 +4390,7 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2012"/>
-        <source>Â¿Deseas eliminar el sonido seleccionado?</source>
+        <source>¿Deseas eliminar el sonido seleccionado?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4404,7 +4404,7 @@ Please check the media service plugins are installed.</source>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2096"/>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2194"/>
-        <source>Para aÃ±adir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
+        <source>Para añadir opciones de compatibilidad debes indicar un ejecutable como minimo.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4430,32 +4430,32 @@ Please check the media service plugins are installed.</source>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Eliminar url...?</source>
+        <source>¿Eliminar url...?</source>
         <translation>Удалить url?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2427"/>
-        <source>Â¿Deseas eliminar esta url?</source>
+        <source>¿Deseas eliminar esta url?</source>
         <translation>В действительно хотите удалить эту ссылку (url)?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Eliminar archivo...?</source>
+        <source>¿Eliminar archivo...?</source>
         <translation>Удалить файл...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="2633"/>
-        <source>Â¿Deseas eliminar este archivo?</source>
+        <source>¿Deseas eliminar este archivo?</source>
         <translation>Вы действительно хотите удалить этот файл?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="86"/>
-        <source>Â¿Cerrar ventana?</source>
+        <source>¿Cerrar ventana?</source>
         <translation>Close window?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="87"/>
-        <source>Â¿Deseas realmente cerrar la ventana?
+        <source>¿Deseas realmente cerrar la ventana?
 Si son nuevos datos o has echo cambios y no guardas puedes perder los cambios efectuados.</source>
         <translation>Do you really wish to close this window?
 Unsaved data / changes will be lost.</translation>
@@ -4467,7 +4467,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1420"/>
-        <source>AÃ±adir grupo</source>
+        <source>Añadir grupo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4477,7 +4477,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_juego.cpp" line="1455"/>
-        <source>AÃ±adir</source>
+        <source>Añadir</source>
         <translation>Добавить</translation>
     </message>
     <message>
@@ -4551,17 +4551,17 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="72"/>
-        <source>Fuerza el uso de la capa ASPI. SÃ³lo en Windows con un ASPI-Layer</source>
+        <source>Fuerza el uso de la capa ASPI. Sólo en Windows con un ASPI-Layer</source>
         <translation>Force ASPI layer usage. Only Windows with ASPI-Layer</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="73"/>
-        <source>SelecciÃ³n automÃ¡tica de la interfaz de audio de CD</source>
+        <source>Selección automática de la interfaz de audio de CD</source>
         <translation>Automatic Audio CD interface</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="74"/>
-        <source>ExtracciÃ³n digital de audio utilizado para los CD de audio</source>
+        <source>Extracción digital de audio utilizado para los CD de audio</source>
         <translation>Digital audio extraction for Audio CD</translation>
     </message>
     <message>
@@ -4576,7 +4576,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="77"/>
-        <source>Fuerza el uso de las SDL para el CD-ROM. VÃ¡lido para todos los sistemas</source>
+        <source>Fuerza el uso de las SDL para el CD-ROM. Válido para todos los sistemas</source>
         <translation>Force SDL for CD-ROM. Available in all systems</translation>
     </message>
     <message>
@@ -4596,16 +4596,16 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Удалить...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_montajes.cpp" line="348"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">В действительно хотите удалить образ ISO из списка?</translation>
     </message>
     <message>
@@ -5310,7 +5310,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="236"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5356,12 +5356,12 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="361"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="390"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Описание</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="386"/>
-        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuraciÃ³n.</source>
+        <source>Ejemplo con la unidad virtual de Alcohol teniendo la siguiente configuración.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5392,17 +5392,17 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="434"/>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="437"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Информация</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation type="unfinished">Удалить...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_addedit_virtual_drive.cpp" line="504"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5494,12 +5494,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="60"/>
-        <source>A la categorÃ­a</source>
+        <source>A la categoría</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_cambiar_categoria.cpp" line="66"/>
-        <source>Selecciona la categorÃ­a de destino</source>
+        <source>Selecciona la categoría de destino</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5563,7 +5563,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_compatibilidad_exe.cpp" line="232"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation type="unfinished">Информация</translation>
     </message>
     <message>
@@ -5665,7 +5665,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="61"/>
-        <source>DiseÃ±ado y programado por</source>
+        <source>Diseñado y programado por</source>
         <translation>Дизайн и программирование</translation>
     </message>
     <message>
@@ -5690,7 +5690,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grdap_acercad.cpp" line="62"/>
-        <source>Texto oculto en el manual del tipo Indiana Jones y la Ãltima Cruzada</source>
+        <source>Texto oculto en el manual del tipo Indiana Jones y la Última Cruzada</source>
         <translation>Скрытый текст в руководстве типа Indiana Jones and the Last Crusade</translation>
     </message>
 </context>
@@ -5723,12 +5723,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="76"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Название</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="80"/>
-        <source>SubtÃ­tulo</source>
+        <source>Subtítulo</source>
         <translation>Подзаголовок</translation>
     </message>
     <message>
@@ -5783,7 +5783,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="145"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
@@ -5793,12 +5793,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="157"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation>Размер</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="162"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Графика</translation>
     </message>
     <message>
@@ -5842,32 +5842,32 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="187"/>
-        <source>CarÃ¡tula frontal</source>
+        <source>Carátula frontal</source>
         <translation>Передняя обложка</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="192"/>
-        <source>CarÃ¡tula trasera</source>
+        <source>Carátula trasera</source>
         <translation>Задняя обложка</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="197"/>
-        <source>CarÃ¡tula lateral izquierdo</source>
+        <source>Carátula lateral izquierdo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="202"/>
-        <source>CarÃ¡tula lateral derecho</source>
+        <source>Carátula lateral derecho</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="207"/>
-        <source>CarÃ¡tula superior</source>
+        <source>Carátula superior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="212"/>
-        <source>CarÃ¡tula inferior</source>
+        <source>Carátula inferior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5897,7 +5897,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_datos.cpp" line="239"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Описание</translation>
     </message>
     <message>
@@ -6539,7 +6539,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_dosbox.cpp" line="660"/>
-        <source>Config - DespuÃ©s del exe</source>
+        <source>Config - Después del exe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6607,13 +6607,13 @@ Unsaved data / changes will be lost.</translation>
     <name>frmImportarJuego</name>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="164"/>
-        <source>InformaciÃ³n</source>
+        <source>Información</source>
         <translation>Информация</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="192"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1432"/>
-        <source>PÃ¡gina</source>
+        <source>Página</source>
         <translation>Страница</translation>
     </message>
     <message>
@@ -6635,12 +6635,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="260"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation type="unfinished">Название</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="261"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation type="unfinished">Год</translation>
     </message>
     <message>
@@ -6651,12 +6651,12 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="293"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="308"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation type="unfinished">Описание</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="294"/>
-        <source>TamaÃ±o</source>
+        <source>Tamaño</source>
         <translation type="unfinished">Размер</translation>
     </message>
     <message>
@@ -6673,7 +6673,7 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="420"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="779"/>
-        <source>InformaciÃ³n no disponible</source>
+        <source>Información no disponible</source>
         <translation>Information not available</translation>
     </message>
     <message>
@@ -6743,13 +6743,13 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="1851"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="1872"/>
-        <source>AÃ±adiendo a la lista</source>
+        <source>Añadiendo a la lista</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_juego.cpp" line="2776"/>
         <location filename="../../src/grlida_importar_juego.cpp" line="2780"/>
-        <source>Importando imÃ¡genes, juego</source>
+        <source>Importando imágenes, juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7076,7 +7076,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="71"/>
-        <source>DescripciÃ³n</source>
+        <source>Descripción</source>
         <translation>Описание</translation>
     </message>
     <message>
@@ -7111,7 +7111,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="101"/>
-        <source>Modo grÃ¡fico:</source>
+        <source>Modo gráfico:</source>
         <translation>Графический режим:</translation>
     </message>
     <message>
@@ -7166,12 +7166,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="148"/>
-        <source>Mostras subtÃ­tulo</source>
+        <source>Mostras subtítulo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="218"/>
-        <source>Velocidad de subtÃ­tulos:</source>
+        <source>Velocidad de subtítulos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7181,12 +7181,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="154"/>
-        <source>Filtro de grÃ¡ficos</source>
+        <source>Filtro de gráficos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="157"/>
-        <source>CorrecciÃ³n de aspecto</source>
+        <source>Corrección de aspecto</source>
         <translation>Аспект коррекции</translation>
     </message>
     <message>
@@ -7241,7 +7241,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="206"/>
-        <source>Volumen mÃºsica:</source>
+        <source>Volumen música:</source>
         <translation>Громкость музыки:</translation>
     </message>
     <message>
@@ -7256,7 +7256,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_importar_scummvm.cpp" line="215"/>
-        <source>Tiempo de la mÃºsica:</source>
+        <source>Tiempo de la música:</source>
         <translation>Темп музыки:</translation>
     </message>
     <message>
@@ -7305,7 +7305,7 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_info.cpp" line="73"/>
         <location filename="../../src/grlida_info.cpp" line="76"/>
-        <source>VersiÃ³n</source>
+        <source>Versión</source>
         <translation>Версия</translation>
     </message>
     <message>
@@ -7425,12 +7425,12 @@ Unsaved data / changes will be lost.</translation>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Удалить...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="475"/>
-        <source>Â¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
+        <source>¿Quieres eliminar la ISO/IMA/IMG de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7440,7 +7440,7 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="706"/>
-        <source>Â¿Quieres eliminar de la lista?</source>
+        <source>¿Quieres eliminar de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7476,12 +7476,12 @@ Unsaved data / changes will be lost.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="828"/>
-        <source>Se ha producido un error en el proceso, tiempo despuÃ©s de empezar con Ã©xito</source>
+        <source>Se ha producido un error en el proceso, tiempo después de empezar con éxito</source>
         <translation type="unfinished">There was an error in the process, time after starting successfully</translation>
     </message>
     <message>
         <location filename="../../src/grlida_instalar_juego.cpp" line="831"/>
-        <source>Se ha producido un error, waitFor...() Ãºltima funciÃ³n el tiempo de espera</source>
+        <source>Se ha producido un error, waitFor...() última función el tiempo de espera</source>
         <translation type="unfinished">There was an error, waitFor...() Last time out function</translation>
     </message>
     <message>
@@ -7500,7 +7500,7 @@ Unsaved data / changes will be lost.</translation>
         <translation type="unfinished">There was an unknown error</translation>
     </message>
     <message>
-        <source>Â¿Quieres eliminar la ISO de la lista?</source>
+        <source>¿Quieres eliminar la ISO de la lista?</source>
         <translation type="obsolete">В действительно хотите удалить образ ISO из списка?</translation>
     </message>
     <message>
@@ -8056,7 +8056,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="417"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Название</translation>
     </message>
     <message>
@@ -8072,7 +8072,7 @@ Compruebe si lo tiene instalado.</source>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="700"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1002"/>
         <location filename="../../src/grlida_list_icon_cfg.cpp" line="1042"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Поддерживаемые образы</translation>
     </message>
     <message>
@@ -8106,7 +8106,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="915"/>
-        <source>PuntuaciÃ³n</source>
+        <source>Puntuación</source>
         <translation>Score</translation>
     </message>
     <message>
@@ -8126,52 +8126,52 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1063"/>
-        <source>DÃ­a del mes sin ceros iniciales (1 a 31).</source>
+        <source>Día del mes sin ceros iniciales (1 a 31).</source>
         <translation>День месяца без ведущих нулей (1 to 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1067"/>
-        <source>DÃ­a del mes, 2 dÃ­gitos con ceros iniciales (01 a 31).</source>
+        <source>Día del mes, 2 dígitos con ceros iniciales (01 a 31).</source>
         <translation>День месяца с ведущим нулем (01 to 31).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1071"/>
-        <source>Una representaciÃ³n textual de un dÃ­a, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
+        <source>Una representación textual de un día, tres letras (e.j. &apos;Lun&apos; a &apos;Dom&apos;).</source>
         <translation>Сокращенное название дня недели (то есть от &apos;Пн&apos; до &apos;Вс&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1075"/>
-        <source>Una representaciÃ³n textual completa del dÃ­a de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
+        <source>Una representación textual completa del día de la semana (e.j. &apos;Lunes&apos; a &apos;Domingo&apos;).</source>
         <translation>Полный день недели (то есть от &apos;Понедельник&apos; to &apos;Воскресенье&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1079"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, sin ceros iniciales (1-12).</source>
+        <source>Representación numérica de un mes, sin ceros iniciales (1-12).</source>
         <translation>Номер месяца без ведущих нулей (1-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1083"/>
-        <source>RepresentaciÃ³n numÃ©rica de un mes, con ceros iniciales (01-12).</source>
+        <source>Representación numérica de un mes, con ceros iniciales (01-12).</source>
         <translation>Номер месяца с ведущим нулем (01-12).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1087"/>
-        <source>Una representaciÃ³n textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
+        <source>Una representación textual corta de un mes, tres letras (e.j. &apos;Ene&apos; a &apos;Dic&apos;).</source>
         <translation>Сокращенное название месяца (то есть от &apos;Янв&apos; до &apos;Дек&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1091"/>
-        <source>Una representaciÃ³n textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
+        <source>Una representación textual completa de un mes, como Enero o Marzo (e.j. &apos;Enero&apos; a &apos;Diciembre&apos;).</source>
         <translation>Полное название месяца (то есть от &apos;Январь&apos; to &apos;Декабрь&apos;).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1095"/>
-        <source>Una representaciÃ³n de dos dÃ­gitos de un aÃ±o (00-99).</source>
+        <source>Una representación de dos dígitos de un año (00-99).</source>
         <translation>Год, как две десятичные цифры (00-99).</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1099"/>
-        <source>Una representaciÃ³n numÃ©rica completa de un aÃ±o, 4 dÃ­gitos.</source>
+        <source>Una representación numérica completa de un año, 4 dígitos.</source>
         <translation>Год как четыре десятичные цифры.</translation>
     </message>
     <message>
@@ -8200,12 +8200,12 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1200"/>
         <location filename="../../src/grlida_opciones.cpp" line="1463"/>
-        <source>Debes poner un tÃ­tulo.</source>
+        <source>Debes poner un título.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1410"/>
-        <source>Â¿Deseas realmente eliminar este DOSBox de la lista?</source>
+        <source>¿Deseas realmente eliminar este DOSBox de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8215,17 +8215,17 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1601"/>
-        <source>Â¿Deseas realmente eliminar este emulador de la lista?</source>
+        <source>¿Deseas realmente eliminar este emulador de la lista?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1672"/>
-        <source>Debes poner el nombre de la tabla para la nueva categorÃ­a.</source>
+        <source>Debes poner el nombre de la tabla para la nueva categoría.</source>
         <translation>You must enter a table name for the new category.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1676"/>
-        <source>Debes poner el tÃ­tulo de la nueva categorÃ­a.</source>
+        <source>Debes poner el título de la nueva categoría.</source>
         <translation>You must enter the name of the new category.</translation>
     </message>
     <message>
@@ -8248,27 +8248,27 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1687"/>
         <location filename="../../src/grlida_opciones.cpp" line="1700"/>
-        <source>Â¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
+        <source>¿La tabla ya existe, quieres usar el siguiente nombre para la tabla?</source>
         <translation>The table already exists. Do you want to use the following name for the table?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1721"/>
-        <source>No se ha podido aÃ±adir la nueva categorÃ­a.</source>
+        <source>No se ha podido añadir la nueva categoría.</source>
         <translation>Couldn&apos;t add the new category.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1733"/>
-        <source>No se ha podido actualizar la categorÃ­a.</source>
+        <source>No se ha podido actualizar la categoría.</source>
         <translation>Couldn&apos;t update the category.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1843"/>
-        <source>Por favor selecciona una categorÃ­a de la lista para eliminarla</source>
+        <source>Por favor selecciona una categoría de la lista para eliminarla</source>
         <translation>Please select a category from the list to delete</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1846"/>
-        <source>No se puede eliminar la tabla de la categorÃ­a.</source>
+        <source>No se puede eliminar la tabla de la categoría.</source>
         <translation>Can&apos;t delete this table from the category.</translation>
     </message>
     <message>
@@ -8283,42 +8283,42 @@ Compruebe si lo tiene instalado.</source>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Eliminar...?</source>
+        <source>¿Eliminar...?</source>
         <translation>Удалить...?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1848"/>
-        <source>Â¿Deseas realmente eliminar esta categorÃ­a de la base de datos?</source>
+        <source>¿Deseas realmente eliminar esta categoría de la base de datos?</source>
         <translation>Do you really wish to delete this category from the database?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2021"/>
-        <source>Â¿Deseas restaurar el menÃº de navegaciÃ³n por defecto?</source>
+        <source>¿Deseas restaurar el menú de navegación por defecto?</source>
         <translation>Do you wish to restore the default navigation menu?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2050"/>
-        <source>Por favor selecciona un menÃº nav de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú nav de la lista para eliminarlo</source>
         <translation>Please select a navigation menu from the list to delete</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2052"/>
-        <source>Â¿Deseas realmente eliminar este menÃº nav de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú nav de la base de datos?</source>
         <translation>Do you really wish to delete this navigation menu from the database?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2223"/>
-        <source>Â¿Deseas restaurar el menÃº de shortcut por defecto?</source>
+        <source>¿Deseas restaurar el menú de shortcut por defecto?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2256"/>
-        <source>Por favor selecciona un menÃº shortcut de la lista para eliminarlo</source>
+        <source>Por favor selecciona un menú shortcut de la lista para eliminarlo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2258"/>
-        <source>Â¿Deseas realmente eliminar este menÃº shortcut de la base de datos?</source>
+        <source>¿Deseas realmente eliminar este menú shortcut de la base de datos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8330,7 +8330,7 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2449"/>
         <location filename="../../src/grlida_opciones.cpp" line="2517"/>
-        <source>TÃ­tulo</source>
+        <source>Título</source>
         <translation>Название</translation>
     </message>
     <message>
@@ -8388,7 +8388,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="880"/>
-        <source>CompaÃ±ia</source>
+        <source>Compañia</source>
         <translation>Компания</translation>
     </message>
     <message>
@@ -8429,14 +8429,14 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="888"/>
-        <source>AÃ±o</source>
+        <source>Año</source>
         <translation>Год</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="889"/>
         <location filename="../../src/grlida_opciones.cpp" line="913"/>
         <location filename="../../src/grlida_opciones.cpp" line="932"/>
-        <source>NÂº discos</source>
+        <source>Nº discos</source>
         <translation>Кол-во дисков</translation>
     </message>
     <message>
@@ -8446,7 +8446,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="891"/>
-        <source>GrÃ¡ficos</source>
+        <source>Gráficos</source>
         <translation>Графика</translation>
     </message>
     <message>
@@ -8483,7 +8483,7 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="899"/>
         <location filename="../../src/grlida_opciones.cpp" line="916"/>
-        <source>CalificaciÃ³n</source>
+        <source>Calificación</source>
         <translation>Рейтинг</translation>
     </message>
     <message>
@@ -8508,7 +8508,7 @@ Compruebe si lo tiene instalado.</source>
         <location filename="../../src/grlida_opciones.cpp" line="906"/>
         <location filename="../../src/grlida_opciones.cpp" line="926"/>
         <location filename="../../src/grlida_opciones.cpp" line="2033"/>
-        <source>CompaÃ±ias</source>
+        <source>Compañias</source>
         <translation>Компании</translation>
     </message>
     <message>
@@ -8546,7 +8546,7 @@ Compruebe si lo tiene instalado.</source>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="912"/>
         <location filename="../../src/grlida_opciones.cpp" line="2034"/>
-        <source>AÃ±os</source>
+        <source>Años</source>
         <translation>Год</translation>
     </message>
     <message>
@@ -8631,12 +8631,12 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="999"/>
-        <source>El proxy se determina sobre la base de la aplicaciÃ³n</source>
+        <source>El proxy se determina sobre la base de la aplicación</source>
         <translation>Прокси определяется на основании настроек приложений</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1002"/>
-        <source>HTTP proxy sÃ³lo para las solicitudes</source>
+        <source>HTTP proxy sólo para las solicitudes</source>
         <translation>Используется прокси только для HTTP запросов</translation>
     </message>
     <message>
@@ -8683,7 +8683,7 @@ Compruebe si lo tiene instalado.</source>
         <location filename="../../src/grlida_opciones.cpp" line="393"/>
         <location filename="../../src/grlida_opciones.cpp" line="500"/>
         <location filename="../../src/grlida_opciones.cpp" line="2437"/>
-        <source>ImÃ¡genes CategorÃ­as</source>
+        <source>Imágenes Categorías</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8694,14 +8694,14 @@ Compruebe si lo tiene instalado.</source>
         <location filename="../../src/grlida_opciones.cpp" line="396"/>
         <location filename="../../src/grlida_opciones.cpp" line="503"/>
         <location filename="../../src/grlida_opciones.cpp" line="2439"/>
-        <source>ImÃ¡genes defecto</source>
+        <source>Imágenes defecto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="324"/>
         <location filename="../../src/grlida_opciones.cpp" line="350"/>
         <location filename="../../src/grlida_opciones.cpp" line="506"/>
-        <source>ImÃ¡genes idiomas</source>
+        <source>Imágenes idiomas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8726,7 +8726,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="989"/>
-        <source>TÃ­tulo descriptivo</source>
+        <source>Título descriptivo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8735,13 +8735,13 @@ Compruebe si lo tiene instalado.</source>
         <location filename="../../src/grlida_opciones.cpp" line="992"/>
         <location filename="../../src/grlida_opciones.cpp" line="993"/>
         <location filename="../../src/grlida_opciones.cpp" line="994"/>
-        <source>TÃ­tulo Juego</source>
+        <source>Título Juego</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1050"/>
         <location filename="../../src/grlida_opciones.cpp" line="1161"/>
-        <source>InformaciÃ³n sobre el formato de la fecha y hora</source>
+        <source>Información sobre el formato de la fecha y hora</source>
         <translation>Форматы отображения даты и времени</translation>
     </message>
     <message>
@@ -8751,13 +8751,13 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1053"/>
-        <source>Lista bÃ¡sica de parÃ¡metros:</source>
+        <source>Lista básica de parámetros:</source>
         <translation>Простейший список параметров:</translation>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="1057"/>
         <location filename="../../src/grlida_opciones.cpp" line="1106"/>
-        <source>ExpresiÃ³n</source>
+        <source>Expresión</source>
         <translation>Выражение</translation>
     </message>
     <message>
@@ -8857,7 +8857,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2602"/>
-        <source>ImÃ¡genes soportadas</source>
+        <source>Imágenes soportadas</source>
         <translation>Поддерживаемые образы</translation>
     </message>
     <message>
@@ -8869,7 +8869,7 @@ Compruebe si lo tiene instalado.</source>
         <location filename="../../src/grlida_opciones.cpp" line="3138"/>
         <location filename="../../src/grlida_opciones.cpp" line="3168"/>
         <location filename="../../src/grlida_opciones.cpp" line="3198"/>
-        <source>Â¿Deseas eliminar la extensiÃ³n?</source>
+        <source>¿Deseas eliminar la extensión?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8889,7 +8889,7 @@ Compruebe si lo tiene instalado.</source>
     </message>
     <message>
         <location filename="../../src/grlida_opciones.cpp" line="2628"/>
-        <source>Â¿Deseas realmente eliminar este dato de la lista?</source>
+        <source>¿Deseas realmente eliminar este dato de la lista?</source>
         <translation>Do you really wish to delete this item from the list?</translation>
     </message>
     <message>
@@ -10218,12 +10218,12 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="532"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Вы должны указать хотя бы название.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="573"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Вы должны указать название игры</translation>
     </message>
     <message>
@@ -10246,22 +10246,22 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Usar montajes?</source>
+        <source>¿Usar montajes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="691"/>
-        <source>Â¿Deseas aÃ±adir los montajes usados?</source>
+        <source>¿Deseas añadir los montajes usados?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Eliminar montaje...?</source>
+        <source>¿Eliminar montaje...?</source>
         <translation>Delete mounting settings?</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_dosbox.cpp" line="824"/>
-        <source>Â¿Deseas eliminar este montaje?</source>
+        <source>¿Deseas eliminar este montaje?</source>
         <translation>Вы действительно хотите удалить это монтирование?</translation>
     </message>
     <message>
@@ -10509,12 +10509,12 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="375"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Вы должны указать хотя бы название.</translation>
     </message>
     <message>
         <location filename="../../src/grlida_wizard_scummvm.cpp" line="415"/>
-        <source>Debes poner un tÃ­tulo al juego</source>
+        <source>Debes poner un título al juego</source>
         <translation>Вы должны указать название игры</translation>
     </message>
     <message>
@@ -10598,7 +10598,7 @@ Pulsa aceptar para cerrar el asistente
     </message>
     <message>
         <location filename="../../src/grlida_wizard_vdmsound.cpp" line="268"/>
-        <source>Debes poner por lo menos el tÃ­tulo.</source>
+        <source>Debes poner por lo menos el título.</source>
         <translation>Вы должны указать хотя бы название.</translation>
     </message>
     <message>


### PR DESCRIPTION
With QT5 the default encoding changed from Latin1 to UTF-8 for .ts
files. Additionally the only supported encodings by the localization
tools are UTF-8 and UTF-16 now.
As a result when using QT5's lupdate on the project several strings
cannot be matched any more, resulting in an incompletely translated GUI.
Change the translation files to UTF-8 and add the appropriate definition
to the project file for backwards compatibility with QT4.